### PR TITLE
feat: ガントチャートに親タスク・担当者フィルタを追加 (issue #2)

### DIFF
--- a/src/components/GanttChart.tsx
+++ b/src/components/GanttChart.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import { Task } from "../types/task";
 import { toHolidayKey } from "../utils/holidays";
+import { getAllDescendantIds } from "../utils/taskUtils";
 import TaskEditModal  from "./TaskEditModal";
 import GanttTooltip  from "./GanttTooltip";
 
@@ -12,7 +13,7 @@ interface Props {
 
 const DAY_WIDTH = 28;
 const ROW_HEIGHT = 40;
-const HEADER_HEIGHT = 60;
+const HEADER_HEIGHT = 90;
 const LEFT_PANEL_WIDTH = 260;
 const ASSIGNEE_COL_WIDTH = 80;
 const PROGRESS_COL_WIDTH = 70;
@@ -145,6 +146,8 @@ export default function GanttChart({ tasks, onTasksChange, holidays = new Map() 
   const leftScrollRef = useRef<HTMLDivElement>(null);
 
   const [collapsedIds, setCollapsedIds] = useState<Set<string>>(new Set());
+  const [filterParentId, setFilterParentId] = useState<string>("all");
+  const [filterAssignee, setFilterAssignee] = useState<string>("all");
 
   // 編集モーダル
   const [editingId, setEditingId] = useState<string | null>(null);
@@ -180,7 +183,29 @@ export default function GanttChart({ tasks, onTasksChange, holidays = new Map() 
     else last.count++;
   });
 
-  const visibleTasks = tasks.filter((t) => isVisible(t, tasks, collapsedIds));
+  // 親タスクフィルタ
+  const filteredByParent = filterParentId === "all"
+    ? tasks
+    : [
+        tasks.find((t) => t.id === filterParentId)!,
+        ...getAllDescendantIds(filterParentId, tasks)
+          .slice(1)
+          .map((id) => tasks.find((t) => t.id === id)!),
+      ].filter(Boolean);
+
+  // 担当者フィルタ（対象担当者の子を持つ親タスク行も表示）
+  const assignees = [...new Set(tasks.map((t) => t.assignee).filter(Boolean))] as string[];
+  const filteredTasks = filterAssignee === "all"
+    ? filteredByParent
+    : filteredByParent.filter((t) =>
+        t.assignee === filterAssignee ||
+        getAllDescendantIds(t.id, tasks).slice(1).some((id) => {
+          const child = tasks.find((c) => c.id === id);
+          return child?.assignee === filterAssignee;
+        })
+      );
+
+  const visibleTasks = filteredTasks.filter((t) => isVisible(t, filteredTasks, collapsedIds));
 
   const today = new Date();
   today.setHours(0, 0, 0, 0);
@@ -309,12 +334,45 @@ export default function GanttChart({ tasks, onTasksChange, holidays = new Map() 
       {/* ── 左パネル ── */}
       <div className="gantt-left" style={{ width: LEFT_PANEL_WIDTH + ASSIGNEE_COL_WIDTH + PROGRESS_COL_WIDTH }}>
         <div className="gantt-left-header" style={{ height: HEADER_HEIGHT }}>
-          <span className="gantt-col-task">
-            タスク名
-            <button className="gantt-add-top-btn" onClick={() => openAdd()} title="ルートタスクを追加">＋</button>
-          </span>
-          <span className="gantt-col-assignee">担当者</span>
-          <span className="gantt-col-progress">進捗</span>
+          <div className="gantt-header-top-row">
+            <span className="gantt-col-task">
+              タスク名
+              <button className="gantt-add-top-btn" onClick={() => openAdd()} title="ルートタスクを追加">＋</button>
+            </span>
+            <span className="gantt-col-assignee">担当者</span>
+            <span className="gantt-col-progress">進捗</span>
+          </div>
+          <div className="gantt-filter-bar">
+            <div className="gantt-filter-item">
+              <span className="gantt-filter-label">親タスク:</span>
+              <select
+                className="gantt-filter-select"
+                value={filterParentId}
+                onChange={(e) => {
+                  setFilterParentId(e.target.value);
+                  setCollapsedIds(new Set());
+                }}
+              >
+                <option value="all">すべて表示</option>
+                {tasks.filter((t) => !t.parentId).map((t) => (
+                  <option key={t.id} value={t.id}>{t.name}</option>
+                ))}
+              </select>
+            </div>
+            <div className="gantt-filter-item">
+              <span className="gantt-filter-label">担当者:</span>
+              <select
+                className="gantt-filter-select"
+                value={filterAssignee}
+                onChange={(e) => setFilterAssignee(e.target.value)}
+              >
+                <option value="all">全員</option>
+                {assignees.map((a) => (
+                  <option key={a} value={a}>{a}</option>
+                ))}
+              </select>
+            </div>
+          </div>
         </div>
 
         <div

--- a/src/styles.css
+++ b/src/styles.css
@@ -113,13 +113,52 @@
 
 .gantt-left-header {
   display: flex;
-  align-items: center;
+  flex-direction: column;
   background: #f7f9fc;
   border-bottom: 2px solid #dde3ed;
   font-weight: 700;
   font-size: 0.8rem;
   color: #555;
   flex-shrink: 0;
+}
+
+.gantt-header-top-row {
+  display: flex;
+  align-items: center;
+  flex: 1;
+  min-height: 0;
+  padding: 4px 0;
+}
+
+.gantt-filter-bar {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  padding: 3px 8px;
+  border-top: 1px solid #dde3ed;
+  font-weight: 400;
+}
+
+.gantt-filter-item {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.gantt-filter-label {
+  font-size: 11px;
+  color: #777;
+  white-space: nowrap;
+}
+
+.gantt-filter-select {
+  font-size: 11px;
+  padding: 2px 4px;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  background: #fff;
+  cursor: pointer;
+  max-width: 120px;
 }
 
 .gantt-col-task {


### PR DESCRIPTION
## Summary

- ガントチャートのヘッダーに「親タスク」「担当者」セレクトボックスを追加
- 親タスクフィルタ: 選択したルートタスクとその全子孫のみ表示、フィルタ切替時に折りたたみをリセット
- 担当者フィルタ: 該当担当者のタスクとその親タスク行を表示（親タスクフィルタと AND 条件）
- `getAllDescendantIds()` を再利用し、`HEADER_HEIGHT` を 60→90px に拡張

Closes #2

## Test plan

- [ ] 「すべて表示」選択時に全タスクが表示されること
- [ ] 親タスクを選択するとそのタスクと全子孫のみ表示されること
- [ ] 担当者を選択すると該当担当者のタスクと親タスク行が表示されること
- [ ] 両フィルタを組み合わせた AND 条件が正しく動作すること
- [ ] フィルタ切替時に折りたたみ状態がリセットされること
- [ ] フィルタ中も折りたたみ（▶▼）が正常動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)