### PR TITLE
feat: タスク実施状況分析画面を追加 (issue #3)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,13 +2,14 @@ import { useEffect, useRef, useState } from "react";
 import GanttChart        from "./components/GanttChart";
 import KanbanBoard       from "./components/KanbanBoard";
 import SearchView        from "./components/SearchView";
+import AnalysisView      from "./components/AnalysisView";
 import ProxySettingModal from "./components/ProxySettingModal";
 import UpdateNotifier    from "./components/UpdateNotifier";
 import { Task }       from "./types/task";
 import { loadTasks, saveTasks } from "./utils/taskStorage";
 import { loadHolidays }         from "./utils/holidays";
 
-type ViewMode = "gantt" | "kanban";
+type ViewMode = "gantt" | "kanban" | "analysis";
 
 function App() {
   const [tasks,    setTasks]    = useState<Task[]>([]);
@@ -105,6 +106,13 @@ function App() {
           >
             🗂 カンバン
           </button>
+          <button
+            className={`view-toggle-btn${viewMode === "analysis" ? " view-toggle-btn--active" : ""}`}
+            onClick={() => { setViewMode("analysis"); setSearchQuery(""); }}
+            title="分析"
+          >
+            📊 分析
+          </button>
         </div>
 
         {/* 設定ボタン */}
@@ -136,6 +144,9 @@ function App() {
         )}
         {!loading && !error && !isSearching && viewMode === "kanban" && (
           <KanbanBoard tasks={tasks} onTasksChange={handleTasksChange} />
+        )}
+        {!loading && !error && !isSearching && viewMode === "analysis" && (
+          <AnalysisView tasks={tasks} />
         )}
       </main>
     </div>

--- a/src/components/AnalysisView.tsx
+++ b/src/components/AnalysisView.tsx
@@ -1,0 +1,134 @@
+import { useMemo } from "react";
+import { Task } from "../types/task";
+import { isLeaf, computeProgress, getAncestorNames } from "../utils/taskUtils";
+
+interface Props {
+  tasks: Task[];
+}
+
+export default function AnalysisView({ tasks }: Props) {
+  const today = useMemo(() => {
+    const d = new Date();
+    d.setHours(0, 0, 0, 0);
+    return d;
+  }, []);
+
+  const leafTasks = useMemo(
+    () => tasks.filter((t) => isLeaf(t.id, tasks)),
+    [tasks]
+  );
+
+  // 遅延タスク: 終了予定日を過ぎているのに未完了
+  const delayedTasks = useMemo(
+    () =>
+      leafTasks.filter(
+        (t) => t.endDate < today && computeProgress(t.id, tasks) < 100
+      ),
+    [leafTasks, tasks, today]
+  );
+
+  // 次のタスクがないメンバー
+  const idleMembers = useMemo(() => {
+    const assignees = [
+      ...new Set(leafTasks.map((t) => t.assignee).filter(Boolean) as string[]),
+    ];
+    return assignees.filter((assignee) => {
+      const activeTasks = leafTasks.filter(
+        (t) =>
+          t.assignee === assignee &&
+          computeProgress(t.id, tasks) < 100 &&
+          t.endDate >= today
+      );
+      return activeTasks.length === 0;
+    });
+  }, [leafTasks, tasks, today]);
+
+  function formatDate(d: Date): string {
+    return `${d.getFullYear()}/${String(d.getMonth() + 1).padStart(2, "0")}/${String(d.getDate()).padStart(2, "0")}`;
+  }
+
+  function delayDays(endDate: Date): number {
+    return Math.floor((today.getTime() - endDate.getTime()) / (1000 * 60 * 60 * 24));
+  }
+
+  return (
+    <div className="analysis-view">
+      {/* 遅延タスク */}
+      <section className="analysis-section">
+        <h2 className="analysis-section-title">
+          <span className="analysis-icon">⚠️</span>
+          遅延タスク
+          <span className="analysis-count">{delayedTasks.length}件</span>
+        </h2>
+
+        {delayedTasks.length === 0 ? (
+          <p className="analysis-empty">遅延タスクはありません</p>
+        ) : (
+          <div className="analysis-table-wrapper">
+            <table className="analysis-table">
+              <thead>
+                <tr>
+                  <th>タスク名</th>
+                  <th>担当者</th>
+                  <th>終了予定日</th>
+                  <th>遅延日数</th>
+                  <th>進捗</th>
+                  <th>パス</th>
+                </tr>
+              </thead>
+              <tbody>
+                {delayedTasks.map((t) => {
+                  const ancestors = getAncestorNames(t.id, tasks);
+                  const progress = computeProgress(t.id, tasks);
+                  const late = delayDays(t.endDate);
+                  const isNotStarted = progress === 0;
+                  return (
+                    <tr key={t.id} className={isNotStarted ? "analysis-row--not-started" : ""}>
+                      <td className="analysis-task-name">{t.name}</td>
+                      <td>{t.assignee || "—"}</td>
+                      <td>{formatDate(t.endDate)}</td>
+                      <td className="analysis-delay">+{late}日</td>
+                      <td>
+                        <div className="analysis-progress-bar">
+                          <div
+                            className="analysis-progress-fill"
+                            style={{ width: `${progress}%` }}
+                          />
+                          <span>{progress}%</span>
+                        </div>
+                      </td>
+                      <td className="analysis-path">
+                        {ancestors.length > 0 ? ancestors.join(" > ") : "—"}
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </section>
+
+      {/* 次のタスクがないメンバー */}
+      <section className="analysis-section">
+        <h2 className="analysis-section-title">
+          <span className="analysis-icon">🕐</span>
+          次のタスクがないメンバー
+          <span className="analysis-count">{idleMembers.length}人</span>
+        </h2>
+
+        {idleMembers.length === 0 ? (
+          <p className="analysis-empty">全員に次のタスクがあります</p>
+        ) : (
+          <div className="analysis-idle-members">
+            {idleMembers.map((member) => (
+              <span key={member} className="analysis-member-chip">
+                {member}
+              </span>
+            ))}
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -1662,4 +1662,149 @@
 .gantt-tooltip .markdown-body th      { background: #334155; }
 .gantt-tooltip .markdown-body td,
 .gantt-tooltip .markdown-body th      { border-color: #334155; }
+
+/* ── Analysis View ── */
+.analysis-view {
+  padding: 24px;
+  overflow-y: auto;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+}
+
+.analysis-section {
+  background: #fff;
+  border-radius: 10px;
+  padding: 20px 24px;
+  box-shadow: 0 1px 4px rgba(0,0,0,0.08);
+}
+
+.analysis-section-title {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 1rem;
+  font-weight: 700;
+  color: #1a1a2e;
+  margin-bottom: 16px;
+}
+
+.analysis-icon {
+  font-size: 1.1rem;
+}
+
+.analysis-count {
+  font-size: 0.82rem;
+  font-weight: 600;
+  background: #e2e8f0;
+  color: #475569;
+  padding: 2px 8px;
+  border-radius: 10px;
+  margin-left: 4px;
+}
+
+.analysis-empty {
+  color: #64748b;
+  font-size: 0.9rem;
+  padding: 8px 0;
+}
+
+.analysis-table-wrapper {
+  overflow-x: auto;
+}
+
+.analysis-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.85rem;
+}
+
+.analysis-table thead th {
+  background: #f1f5f9;
+  color: #475569;
+  font-weight: 600;
+  padding: 8px 12px;
+  text-align: left;
+  border-bottom: 2px solid #e2e8f0;
+  white-space: nowrap;
+}
+
+.analysis-table tbody td {
+  padding: 8px 12px;
+  border-bottom: 1px solid #f1f5f9;
+  vertical-align: middle;
+}
+
+.analysis-table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.analysis-table tbody tr:hover td {
+  background: #f8fafc;
+}
+
+.analysis-row--not-started td {
+  background: #fef9f0 !important;
+}
+
+.analysis-task-name {
+  font-weight: 600;
+  color: #1e293b;
+  max-width: 220px;
+}
+
+.analysis-delay {
+  font-weight: 700;
+  color: #dc2626;
+}
+
+.analysis-path {
+  color: #94a3b8;
+  font-size: 0.78rem;
+  max-width: 260px;
+}
+
+.analysis-progress-bar {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 80px;
+}
+
+.analysis-progress-bar > div {
+  flex: 1;
+  height: 6px;
+  background: #e2e8f0;
+  border-radius: 3px;
+  overflow: hidden;
+}
+
+.analysis-progress-fill {
+  height: 100%;
+  background: #3b82f6;
+  border-radius: 3px;
+}
+
+.analysis-progress-bar > span {
+  font-size: 0.78rem;
+  color: #475569;
+  white-space: nowrap;
+}
+
+.analysis-idle-members {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.analysis-member-chip {
+  background: #fef3c7;
+  color: #92400e;
+  border: 1px solid #fcd34d;
+  border-radius: 20px;
+  padding: 4px 14px;
+  font-size: 0.88rem;
+  font-weight: 600;
+}
 .gantt-tooltip .markdown-body tr:nth-child(even) td { background: #253447; }


### PR DESCRIPTION
## Summary

- `AnalysisView.tsx` を新規作成し、タスク実施状況を分析する画面を追加
- **遅延タスク一覧**: 終了予定日を過ぎて未完了のリーフタスクを表示（タスク名・担当者・終了予定日・遅延日数・進捗・祖先パス）
- **次のタスクがないメンバー一覧**: 未完了かつ今日以降の終了予定タスクを持たない担当者を表示
- `App.tsx` に `ViewMode "analysis"` を追加し、ナビゲーションに「📊 分析」ボタンを追加
- `styles.css` に分析画面用スタイルを追加

## Test plan

- [ ] ナビゲーションバーに「📊 分析」ボタンが表示される
- [ ] 分析画面に遅延タスク一覧が表示される（終了予定日超過・未完了のリーフタスク）
- [ ] 遅延件数が 0 件の場合「遅延タスクはありません」と表示される
- [ ] 次のタスクがないメンバーが一覧表示される
- [ ] 対象者が 0 人の場合「全員に次のタスクがあります」と表示される
- [ ] 検索中は分析画面が非表示になり SearchView に切り替わる

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)