### PR TITLE
feat: ガント・カンバンに信号機インジケーターを追加 (issue #4)

### DIFF
--- a/src/components/GanttChart.tsx
+++ b/src/components/GanttChart.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import { Task } from "../types/task";
 import { toHolidayKey } from "../utils/holidays";
-import { getAllDescendantIds } from "../utils/taskUtils";
+import { getAllDescendantIds, getSignalStatus, SignalStatus } from "../utils/taskUtils";
 import TaskEditModal  from "./TaskEditModal";
 import GanttTooltip  from "./GanttTooltip";
 
@@ -95,6 +95,22 @@ function isVisible(task: Task, tasks: Task[], collapsedIds: Set<string>): boolea
   const parent = tasks.find((t) => t.id === task.parentId);
   if (!parent) return true;
   return isVisible(parent, tasks, collapsedIds);
+}
+
+const SIGNAL_TITLE: Record<string, string> = {
+  red: "遅延",
+  yellow: "着手遅れ",
+  green: "正常",
+};
+
+function SignalDot({ status }: { status: SignalStatus }) {
+  if (status === "none") return null;
+  return (
+    <span
+      className={`status-signal status-signal--${status}`}
+      title={SIGNAL_TITLE[status]}
+    />
+  );
 }
 
 function isLeaf(taskId: string, tasks: Task[]): boolean {
@@ -404,6 +420,7 @@ export default function GanttChart({ tasks, onTasksChange, holidays = new Map() 
                   ) : (
                     <span className="gantt-leaf-icon">─</span>
                   )}
+                  <SignalDot status={getSignalStatus(task.id, tasks)} />
                   {task.name}
                   <button
                     className="gantt-add-subtask-btn"

--- a/src/components/KanbanBoard.tsx
+++ b/src/components/KanbanBoard.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { Task } from "../types/task";
-import { getAllDescendantIds } from "../utils/taskUtils";
+import { getAllDescendantIds, getSignalStatus } from "../utils/taskUtils";
 import MemoWithToggle from "./MemoWithToggle";
 import TaskEditModal from "./TaskEditModal";
 
@@ -264,6 +264,13 @@ export default function KanbanBoard({ tasks, onTasksChange }: Props) {
                     onClick={() => openEdit(task)}
                     style={{ borderLeftColor: task.color ?? "#4A90D9" }}
                   >
+                    {/* 信号機インジケーター */}
+                    {(() => {
+                      const sig = getSignalStatus(task.id, tasks);
+                      if (sig === "none") return null;
+                      const title = sig === "red" ? "遅延" : sig === "yellow" ? "着手遅れ" : "正常";
+                      return <span className={`status-signal status-signal--${sig} kanban-card-signal`} title={title} />;
+                    })()}
                     {/* 祖先パス */}
                     {ancestors.length > 0 && (
                       <div className="kanban-card-path">

--- a/src/styles.css
+++ b/src/styles.css
@@ -1808,3 +1808,28 @@
   font-weight: 600;
 }
 .gantt-tooltip .markdown-body tr:nth-child(even) td { background: #253447; }
+
+/* ── 信号機インジケーター ─────────────────────────────── */
+.status-signal {
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  vertical-align: middle;
+  margin-right: 4px;
+}
+
+.status-signal--red    { background: #e53935; box-shadow: 0 0 4px #e5393580; }
+.status-signal--yellow { background: #f9a825; box-shadow: 0 0 4px #f9a82580; }
+.status-signal--green  { background: #43a047; box-shadow: 0 0 4px #43a04780; }
+
+/* カンバンカード右上に絶対配置 */
+.kanban-card-signal {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  width: 12px;
+  height: 12px;
+  margin-right: 0;
+}

--- a/src/utils/taskUtils.ts
+++ b/src/utils/taskUtils.ts
@@ -49,3 +49,17 @@ export function toInputDate(d: Date): string {
 export function genId(): string {
   return Date.now().toString(36) + Math.random().toString(36).slice(2, 7);
 }
+
+export type SignalStatus = "red" | "yellow" | "green" | "none";
+
+export function getSignalStatus(taskId: string, tasks: Task[]): SignalStatus {
+  const effectiveProgress = computeProgress(taskId, tasks);
+  if (effectiveProgress === 100) return "none";
+  const task = tasks.find((t) => t.id === taskId);
+  if (!task) return "none";
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  if (task.endDate < today) return "red";
+  if (task.startDate < today && effectiveProgress === 0) return "yellow";
+  return "green";
+}


### PR DESCRIPTION
## Summary

- `taskUtils.ts` に `getSignalStatus()` 関数を追加し、信号機判定ロジックを集約
- ガントチャートの左パネル各タスク行のタスク名左隣に信号機ドットを表示
- カンバンボードの各カード右上に信号機ドットを表示

## 信号機の定義

| 色 | 意味 | 条件 |
|---|------|------|
| 🔴 レッド | 遅延 | `endDate < today && progress < 100` |
| 🟡 イエロー | 着手遅れ | `startDate < today && progress === 0` |
| 🟢 グリーン | 正常 | 上記以外かつ未完了 |
| 非表示 | 完了 | `progress === 100` |

## Changes

- `src/utils/taskUtils.ts`: `SignalStatus` 型と `getSignalStatus()` を追加
- `src/components/GanttChart.tsx`: `SignalDot` コンポーネントを追加、各タスク行に挿入
- `src/components/KanbanBoard.tsx`: 各カードの右上にシグナルドットを追加
- `src/styles.css`: `.status-signal` 系スタイルを追加

## Test plan

- [ ] ガントチャートの各タスク行にシグナルドットが表示されること
- [ ] カンバンボードの各カード右上にシグナルドットが表示されること
- [ ] 完了タスクにはインジケーターが表示されないこと
- [ ] 期限超過・未完了タスクが🔴レッドで表示されること
- [ ] 開始日超過・未着手タスクが🟡イエローで表示されること
- [ ] 正常進行中タスクが🟢グリーンで表示されること
- [ ] ホバー時に tooltip でステータスのテキストが表示されること

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)