### PR TITLE
feat: タスク名編集機能を追加 (issue #6)

### DIFF
--- a/src/components/GanttChart.tsx
+++ b/src/components/GanttChart.tsx
@@ -168,6 +168,9 @@ export default function GanttChart({ tasks, onTasksChange, holidays = new Map() 
   // 編集モーダル
   const [editingId, setEditingId] = useState<string | null>(null);
 
+  // インライン名前編集
+  const [editingNameId, setEditingNameId] = useState<string | null>(null);
+
   // 追加モーダル
   const [addState, setAddState] = useState<AddState | null>(null);
 
@@ -239,6 +242,14 @@ export default function GanttChart({ tasks, onTasksChange, holidays = new Map() 
 
   function openEdit(task: Task) {
     setEditingId(task.id);
+  }
+
+  function commitRename(taskId: string, newName: string) {
+    const trimmed = newName.trim();
+    if (trimmed) {
+      onTasksChange(tasks.map((t) => t.id === taskId ? { ...t, name: trimmed } : t));
+    }
+    setEditingNameId(null);
   }
 
   function openAdd(parentId?: string) {
@@ -421,7 +432,24 @@ export default function GanttChart({ tasks, onTasksChange, holidays = new Map() 
                     <span className="gantt-leaf-icon">─</span>
                   )}
                   <SignalDot status={getSignalStatus(task.id, tasks)} />
-                  <span className="gantt-task-name" title={task.name}>{task.name}</span>
+                  {editingNameId === task.id ? (
+                    <input
+                      className="gantt-task-name-input"
+                      defaultValue={task.name}
+                      autoFocus
+                      onBlur={(e) => commitRename(task.id, e.target.value)}
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter") commitRename(task.id, e.currentTarget.value);
+                        if (e.key === "Escape") setEditingNameId(null);
+                      }}
+                    />
+                  ) : (
+                    <span
+                      className="gantt-task-name"
+                      title={task.name}
+                      onDoubleClick={() => setEditingNameId(task.id)}
+                    >{task.name}</span>
+                  )}
                 </span>
                 <button
                   className="gantt-add-subtask-btn"

--- a/src/components/TaskEditModal.tsx
+++ b/src/components/TaskEditModal.tsx
@@ -25,6 +25,7 @@ export default function TaskEditModal({ task, tasks, onSave, onDelete, onClose }
   const leaf        = isLeaf(task.id, tasks);
   const hasChildren = tasks.some((t) => t.parentId === task.id);
 
+  const [editName,      setEditName]      = useState(task.name);
   const [editProgress,  setEditProgress]  = useState(task.progress);
   const [editAssignee,  setEditAssignee]  = useState(task.assignee  ?? "");
   const [editStartDate, setEditStartDate] = useState(toInputDate(task.startDate));
@@ -43,6 +44,7 @@ export default function TaskEditModal({ task, tasks, onSave, onDelete, onClose }
       t.id === task.id
         ? {
             ...t,
+            name:      editName.trim() || task.name,
             progress:  editProgress,
             assignee:  editAssignee  || undefined,
             startDate: newStart,
@@ -63,7 +65,13 @@ export default function TaskEditModal({ task, tasks, onSave, onDelete, onClose }
   return (
     <div className="gantt-modal-overlay" onClick={handleSave}>
       <div className="gantt-modal" onClick={(e) => e.stopPropagation()}>
-        <h3>{task.name}</h3>
+        <input
+          type="text"
+          value={editName}
+          onChange={(e) => setEditName(e.target.value)}
+          className="task-name-input"
+          placeholder="タスク名を入力"
+        />
 
         {/* 期間 */}
         <div className="modal-date-row">

--- a/src/styles.css
+++ b/src/styles.css
@@ -177,6 +177,19 @@
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
+  cursor: default;
+}
+
+.gantt-task-name-input {
+  flex: 1;
+  min-width: 0;
+  padding: 1px 4px;
+  border: 1px solid #4a90d9;
+  border-radius: 4px;
+  font-size: inherit;
+  font-family: inherit;
+  outline: none;
+  background: #fff;
 }
 
 .gantt-col-assignee {
@@ -631,6 +644,24 @@
 .gantt-modal h3 {
   font-size: 1rem;
   color: #1a1a2e;
+}
+
+.task-name-input {
+  width: 100%;
+  padding: 6px 10px;
+  border: 1px solid #dde3ed;
+  border-radius: 6px;
+  font-size: 1rem;
+  font-weight: 600;
+  color: #1a1a2e;
+  outline: none;
+  transition: border-color 0.2s;
+  font-family: inherit;
+  box-sizing: border-box;
+}
+
+.task-name-input:focus {
+  border-color: #4a90d9;
 }
 
 /* プロキシ設定モーダル */


### PR DESCRIPTION
## 概要

- `TaskEditModal` のタスク名をクリックして編集できるように `<h3>` → `<input>` に変更
- ガントチャート左パネルでタスク名をダブルクリックしてインライン編集できる機能を追加

## 変更内容

- **TaskEditModal.tsx**: `editName` state 追加、`<h3>` → `<input class="task-name-input">` 変更、`handleSave` に `name` を追加
- **GanttChart.tsx**: `editingNameId` state と `commitRename` 関数を追加、`gantt-task-name` をダブルクリックで `input` に切り替え
- **styles.css**: `.task-name-input`（モーダル用）と `.gantt-task-name-input`（インライン用）のスタイルを追加

## 受け入れ条件チェック

- [x] TaskEditModal のタスク名欄が編集可能な `input` になる
- [x] 変更したタスク名が保存される
- [x] タスク名を空にして保存した場合は元の名前を維持する（バリデーション）
- [x] ガントチャート・カンバン・検索結果のいずれからモーダルを開いても名前を変更できる
- [x] ガントチャート左パネルでダブルクリックによるインライン編集ができる
- [x] インライン編集中に Enter で確定、Escape でキャンセルできる

## Test plan

- [ ] ガントチャートのモーダルからタスク名を変更して保存し、名前が反映されることを確認
- [ ] カンバン・検索結果のモーダルからも同様に名前変更できることを確認
- [ ] 空文字で保存した場合に元の名前が維持されることを確認
- [ ] ガントチャート左パネルでタスク名をダブルクリックして編集できることを確認
- [ ] Enter キーで確定、Escape キーでキャンセルできることを確認

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)