### PR TITLE
fix: カンバンカードの信号機インジケーター表示位置を修正

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -1320,6 +1320,7 @@
 
 /* ── カード ── */
 .kanban-card {
+  position: relative;
   background: #fff;
   border-radius: 8px;
   border-left: 4px solid #4a90d9;


### PR DESCRIPTION
## Summary
- `.kanban-card` に `position: relative` が欠如していたため、`position: absolute` の信号機インジケーター (`.kanban-card-signal`) がウィンドウ右上端に表示されていたバグを修正

## Test plan
- [ ] カンバンビューで遅延タスクのカード右上に赤いドットが表示されることを確認
- [ ] 着手遅れタスクのカード右上に黄色いドットが表示されることを確認
- [ ] 正常タスクにはドットが表示されないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)