### PR TITLE
refactor: 重複関数を taskUtils.ts のインポートに統一 (issue #17)

### DIFF
--- a/src/components/GanttChart.tsx
+++ b/src/components/GanttChart.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import { Task } from "../types/task";
 import { toHolidayKey } from "../utils/holidays";
-import { getAllDescendantIds, getSignalStatus, SignalStatus } from "../utils/taskUtils";
+import { getAllDescendantIds, getSignalStatus, SignalStatus, toInputDate, genId, isLeaf, computeProgress, propagateDates } from "../utils/taskUtils";
 import TaskEditModal  from "./TaskEditModal";
 import GanttTooltip  from "./GanttTooltip";
 
@@ -58,17 +58,6 @@ function addDays(d: Date, n: number): Date {
   return r;
 }
 
-function toInputDate(d: Date): string {
-  const y = d.getFullYear();
-  const m = String(d.getMonth() + 1).padStart(2, "0");
-  const day = String(d.getDate()).padStart(2, "0");
-  return `${y}-${m}-${day}`;
-}
-
-function genId(): string {
-  return Date.now().toString(36) + Math.random().toString(36).slice(2, 7);
-}
-
 function formatDate(d: Date): string {
   return `${d.getMonth() + 1}/${d.getDate()}`;
 }
@@ -113,19 +102,6 @@ function SignalDot({ status }: { status: SignalStatus }) {
   );
 }
 
-function isLeaf(taskId: string, tasks: Task[]): boolean {
-  return !tasks.some((t) => t.parentId === taskId);
-}
-
-function computeProgress(taskId: string, tasks: Task[]): number {
-  const children = tasks.filter((t) => t.parentId === taskId);
-  if (children.length === 0) {
-    return tasks.find((t) => t.id === taskId)?.progress ?? 0;
-  }
-  const avg = children.reduce((sum, c) => sum + computeProgress(c.id, tasks), 0) / children.length;
-  return Math.round(avg);
-}
-
 function expectedProgress(task: Task, today: Date): number {
   if (today <= task.startDate) return 0;
   if (today >= task.endDate) return 100;
@@ -133,22 +109,6 @@ function expectedProgress(task: Task, today: Date): number {
   const elapsed = diffDays(task.startDate, today);
   return Math.round((elapsed / total) * 100);
 }
-
-function propagateDates(changedId: string, tasks: Task[]): Task[] {
-  const task = tasks.find((t) => t.id === changedId);
-  if (!task?.parentId) return tasks;
-
-  const parentId = task.parentId;
-  const siblings = tasks.filter((t) => t.parentId === parentId);
-  const newStart = siblings.reduce((m, t) => (t.startDate < m ? t.startDate : m), siblings[0].startDate);
-  const newEnd   = siblings.reduce((m, t) => (t.endDate   > m ? t.endDate   : m), siblings[0].endDate);
-
-  const updated = tasks.map((t) =>
-    t.id === parentId ? { ...t, startDate: newStart, endDate: newEnd } : t
-  );
-  return propagateDates(parentId, updated);
-}
-
 
 function barOpacity(depth: number): string {
   const opacities = ["ff", "cc", "99", "77"];

--- a/src/components/KanbanBoard.tsx
+++ b/src/components/KanbanBoard.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { Task } from "../types/task";
-import { getAllDescendantIds, getSignalStatus } from "../utils/taskUtils";
+import { getAllDescendantIds, getSignalStatus, isLeaf, computeProgress, getAncestorNames, toInputDate, genId } from "../utils/taskUtils";
 import MemoWithToggle from "./MemoWithToggle";
 import TaskEditModal from "./TaskEditModal";
 
@@ -11,40 +11,8 @@ interface Props {
 
 // ── ヘルパー ─────────────────────────────────────────────
 
-function isLeaf(taskId: string, tasks: Task[]): boolean {
-  return !tasks.some((t) => t.parentId === taskId);
-}
-
-function computeProgress(taskId: string, tasks: Task[]): number {
-  const children = tasks.filter((t) => t.parentId === taskId);
-  if (children.length === 0) return tasks.find((t) => t.id === taskId)?.progress ?? 0;
-  const avg = children.reduce((sum, c) => sum + computeProgress(c.id, tasks), 0) / children.length;
-  return Math.round(avg);
-}
-
-
-/** ルートから対象タスクまでの祖先名を配列で返す（自身は含まない） */
-function getAncestorNames(taskId: string, tasks: Task[]): string[] {
-  const task = tasks.find((t) => t.id === taskId);
-  if (!task?.parentId) return [];
-  const parent = tasks.find((t) => t.id === task.parentId);
-  if (!parent) return [];
-  return [...getAncestorNames(parent.id, tasks), parent.name];
-}
-
-function toInputDate(d: Date): string {
-  const y = d.getFullYear();
-  const m = String(d.getMonth() + 1).padStart(2, "0");
-  const day = String(d.getDate()).padStart(2, "0");
-  return `${y}-${m}-${day}`;
-}
-
 function formatDateShort(d: Date): string {
   return `${d.getMonth() + 1}/${d.getDate()}`;
-}
-
-function genId(): string {
-  return Date.now().toString(36) + Math.random().toString(36).slice(2, 7);
 }
 
 // ── カラム定義 ────────────────────────────────────────────

--- a/src/utils/taskStorage.ts
+++ b/src/utils/taskStorage.ts
@@ -1,6 +1,7 @@
 import { invoke } from "@tauri-apps/api/core";
 import { Task } from "../types/task";
 import { loadSampleTasks } from "../data/sampleData";
+import { toInputDate } from "./taskUtils";
 
 // ── JSON ↔ Task 変換 ──────────────────────────────────────
 
@@ -29,10 +30,7 @@ function toTask(raw: TaskRaw): Task {
 }
 
 function toRaw(task: Task): TaskRaw {
-  const pad = (n: number) => String(n).padStart(2, "0");
-  const fmt = (d: Date) =>
-    `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
-  return { ...task, startDate: fmt(task.startDate), endDate: fmt(task.endDate) };
+  return { ...task, startDate: toInputDate(task.startDate), endDate: toInputDate(task.endDate) };
 }
 
 // ── 読み込み ────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- `GanttChart.tsx` のローカル関数 (`toInputDate`, `genId`, `isLeaf`, `computeProgress`, `propagateDates`) を削除し `taskUtils.ts` からインポートに統一
- `KanbanBoard.tsx` のローカル関数 (`isLeaf`, `computeProgress`, `getAncestorNames`, `toInputDate`, `genId`) を削除し `taskUtils.ts` からインポートに統一
- `taskStorage.ts` の `toRaw` 内の `fmt` 関数を `toInputDate` で置き換え

Closes #17

## Test plan

- [ ] ビルドが成功すること (`npm run build`)
- [ ] ガントチャートの表示・タスク追加・日付ドラッグが正常に動作すること
- [ ] カンバンボードの表示・タスク追加・ドラッグ&ドロップが正常に動作すること
- [ ] タスクの保存・読み込みが正常に動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)