### PR TITLE
fix: updaterターゲットを追加してlatest.jsonが生成されるよう修正

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -31,7 +31,7 @@
   },
   "bundle": {
     "active": true,
-    "targets": ["nsis"],
+    "targets": ["nsis", "updater"],
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",


### PR DESCRIPTION
## Summary

- `bundle.targets` に `"updater"` を追加
- これにより `tauri-action` が署名ファイル（`.sig`）を検出し、`latest.json` を GitHub Release にアップロードするようになる
- 修正前は `Signature not found for the updater JSON. Skipping upload...` というログが出て `latest.json` がスキップされていた

## Test plan

- [ ] `v*` タグをプッシュして GitHub Actions を実行
- [ ] リリースアセットに `latest.json` が含まれることを確認
- [ ] 自動更新が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)