### PR TITLE
refactor: タスク追加モーダルとSignalDotを共通コンポーネントに切り出す（issue #19）

### DIFF
--- a/src/components/GanttChart.tsx
+++ b/src/components/GanttChart.tsx
@@ -1,31 +1,18 @@
 import { useRef, useState } from "react";
 import { Task } from "../types/task";
-import { toInputDate, genId, propagateDates } from "../utils/taskUtils";
+import { propagateDates } from "../utils/taskUtils";
 import { useDragHandler } from "../hooks/useDragHandler";
 import { useGanttFilter } from "../hooks/useGanttFilter";
 import GanttLeftPanel from "./GanttLeftPanel";
 import GanttTimeline  from "./GanttTimeline";
 import TaskEditModal  from "./TaskEditModal";
+import TaskAddModal   from "./TaskAddModal";
 import GanttTooltip   from "./GanttTooltip";
 
 interface Props {
   tasks: Task[];
   onTasksChange: (tasks: Task[]) => void;
   holidays?: Map<string, string>;
-}
-
-interface AddState {
-  parentId?: string;
-  name: string;
-  startDate: string;
-  endDate: string;
-  color: string;
-}
-
-function addDays(d: Date, n: number): Date {
-  const r = new Date(d);
-  r.setDate(r.getDate() + n);
-  return r;
 }
 
 function isVisible(task: Task, tasks: Task[], collapsedIds: Set<string>): boolean {
@@ -43,11 +30,8 @@ export default function GanttChart({ tasks, onTasksChange, holidays = new Map() 
   const [collapsedIds,   setCollapsedIds]   = useState<Set<string>>(new Set());
   const [editingId,      setEditingId]      = useState<string | null>(null);
   const [editingNameId,  setEditingNameId]  = useState<string | null>(null);
-  const [addState,       setAddState]       = useState<AddState | null>(null);
+  const [addParentId,    setAddParentId]    = useState<string | null | undefined>(undefined);
   const [tooltip, setTooltip] = useState<{ task: Task; progress: number; x: number; y: number } | null>(null);
-
-  const today = new Date();
-  today.setHours(0, 0, 0, 0);
 
   // カスタムフック
   const { didDragRef, dragPreview, startDrag } = useDragHandler(tasks, onTasksChange, () => setTooltip(null));
@@ -81,37 +65,7 @@ export default function GanttChart({ tasks, onTasksChange, holidays = new Map() 
   }
 
   function openAdd(parentId?: string) {
-    const parent       = parentId ? tasks.find((t) => t.id === parentId) : undefined;
-    const defaultColor = parent?.color ?? "#4A90D9";
-    setAddState({
-      parentId,
-      name: "",
-      startDate: toInputDate(today),
-      endDate:   toInputDate(addDays(today, 6)),
-      color:     defaultColor,
-    });
-  }
-
-  function confirmAdd() {
-    if (!addState || !addState.name.trim()) return;
-    const newStart = new Date(addState.startDate);
-    const newEnd   = new Date(addState.endDate);
-    if (isNaN(newStart.getTime()) || isNaN(newEnd.getTime()) || newStart > newEnd) return;
-
-    const newTask: Task = {
-      id:        genId(),
-      name:      addState.name.trim(),
-      startDate: newStart,
-      endDate:   newEnd,
-      progress:  0,
-      color:     addState.color,
-      parentId:  addState.parentId,
-    };
-
-    const appended   = [...tasks, newTask];
-    const propagated = newTask.parentId ? propagateDates(newTask.id, appended) : appended;
-    onTasksChange(propagated);
-    setAddState(null);
+    setAddParentId(parentId ?? null);
   }
 
   // ── スクロール同期 ──
@@ -191,50 +145,19 @@ export default function GanttChart({ tasks, onTasksChange, holidays = new Map() 
       })()}
 
       {/* 追加モーダル */}
-      {addState !== null && (() => {
-        const parent = addState.parentId ? tasks.find((t) => t.id === addState.parentId) : undefined;
-        return (
-          <div className="gantt-modal-overlay" onClick={() => setAddState(null)}>
-            <div className="gantt-modal" onClick={(e) => e.stopPropagation()}>
-              <h3>{parent ? "サブタスクを追加" : "タスクを追加"}</h3>
-              {parent && <p className="modal-parent-info">親タスク: {parent.name}</p>}
-
-              <label className="modal-label">タスク名 <span className="modal-required">*</span></label>
-              <input
-                type="text"
-                value={addState.name}
-                onChange={(e) => setAddState({ ...addState, name: e.target.value })}
-                placeholder="タスク名を入力"
-                className="assignee-input"
-                autoFocus
-                onKeyDown={(e) => { if (e.key === "Enter") confirmAdd(); }}
-              />
-
-              <div className="modal-date-row">
-                <div className="modal-date-field">
-                  <label className="modal-label">開始日</label>
-                  <input type="date" value={addState.startDate} max={addState.endDate} onChange={(e) => setAddState({ ...addState, startDate: e.target.value })} className="date-input" />
-                </div>
-                <div className="modal-date-field">
-                  <label className="modal-label">終了日</label>
-                  <input type="date" value={addState.endDate} min={addState.startDate} onChange={(e) => setAddState({ ...addState, endDate: e.target.value })} className="date-input" />
-                </div>
-              </div>
-
-              <div className="modal-color-row">
-                <label className="modal-label">カラー</label>
-                <input type="color" value={addState.color} onChange={(e) => setAddState({ ...addState, color: e.target.value })} className="color-input" />
-                <span className="modal-color-preview" style={{ background: addState.color }} />
-              </div>
-
-              <div className="gantt-modal-actions">
-                <button className="btn-cancel" onClick={() => setAddState(null)}>キャンセル</button>
-                <button className="btn-save" onClick={confirmAdd} disabled={!addState.name.trim()}>追加</button>
-              </div>
-            </div>
-          </div>
-        );
-      })()}
+      {addParentId !== undefined && (
+        <TaskAddModal
+          parentTask={addParentId ? tasks.find((t) => t.id === addParentId) : undefined}
+          allTasks={tasks}
+          onConfirm={(newTask) => {
+            const appended   = [...tasks, newTask];
+            const propagated = newTask.parentId ? propagateDates(newTask.id, appended) : appended;
+            onTasksChange(propagated);
+            setAddParentId(undefined);
+          }}
+          onClose={() => setAddParentId(undefined)}
+        />
+      )}
     </div>
   );
 }

--- a/src/components/GanttLeftPanel.tsx
+++ b/src/components/GanttLeftPanel.tsx
@@ -1,6 +1,6 @@
 import { Task } from "../types/task";
 import { getSignalStatus, isLeaf, computeProgress } from "../utils/taskUtils";
-import { SignalStatus } from "../utils/taskUtils";
+import SignalDot from "./SignalDot";
 
 const ROW_HEIGHT = 40;
 const HEADER_HEIGHT = 90;
@@ -8,22 +8,6 @@ const LEFT_PANEL_WIDTH = 260;
 const ASSIGNEE_COL_WIDTH = 80;
 const PROGRESS_COL_WIDTH = 70;
 const INDENT_PER_LEVEL = 16;
-
-const SIGNAL_TITLE: Record<string, string> = {
-  red: "遅延",
-  yellow: "着手遅れ",
-  green: "正常",
-};
-
-function SignalDot({ status }: { status: SignalStatus }) {
-  if (status === "none") return null;
-  return (
-    <span
-      className={`status-signal status-signal--${status}`}
-      title={SIGNAL_TITLE[status]}
-    />
-  );
-}
 
 function diffDays(a: Date, b: Date): number {
   return Math.round((b.getTime() - a.getTime()) / (1000 * 60 * 60 * 24));

--- a/src/components/KanbanBoard.tsx
+++ b/src/components/KanbanBoard.tsx
@@ -1,8 +1,10 @@
 import { useState } from "react";
 import { Task } from "../types/task";
-import { getAllDescendantIds, getSignalStatus, isLeaf, computeProgress, getAncestorNames, toInputDate, genId } from "../utils/taskUtils";
+import { getAllDescendantIds, getSignalStatus, isLeaf, computeProgress, getAncestorNames } from "../utils/taskUtils";
 import MemoWithToggle from "./MemoWithToggle";
 import TaskEditModal from "./TaskEditModal";
+import TaskAddModal from "./TaskAddModal";
+import SignalDot from "./SignalDot";
 
 interface Props {
   tasks: Task[];
@@ -52,13 +54,9 @@ const COLUMNS: Column[] = [
 
 // ── 追加用ステート型 ──────────────────────────────────────
 
-interface AddState {
-  columnId: Column["id"];
-  name: string;
-  startDate: string;
-  endDate: string;
-  color: string;
-  parentId?: string;
+interface AddColumnState {
+  initialProgress: number;
+  defaultParentId?: string;
 }
 
 // ── コンポーネント ────────────────────────────────────────
@@ -67,7 +65,7 @@ export default function KanbanBoard({ tasks, onTasksChange }: Props) {
   const [editingId,    setEditingId]    = useState<string | null>(null);
   const [expandedMemos, setExpandedMemos] = useState<Set<string>>(new Set());
 
-  const [addState, setAddState] = useState<AddState | null>(null);
+  const [addColumn, setAddColumn] = useState<AddColumnState | null>(null);
 
   const [filterParentId, setFilterParentId] = useState<string | "all">("all");
   const [filterAssignee, setFilterAssignee] = useState<string | "all">("all");
@@ -107,36 +105,11 @@ export default function KanbanBoard({ tasks, onTasksChange }: Props) {
   }
 
   function openAdd(columnId: Column["id"]) {
-    const today = new Date();
-    setAddState({
-      columnId,
-      name:      "",
-      startDate: toInputDate(today),
-      endDate:   toInputDate(new Date(today.getTime() + 6 * 86400000)),
-      color:     "#4A90D9",
-      parentId:  filterParentId === "all" ? undefined : filterParentId,
+    const col = COLUMNS.find((c) => c.id === columnId)!;
+    setAddColumn({
+      initialProgress: col.dropProgress(0),
+      defaultParentId: filterParentId === "all" ? undefined : filterParentId,
     });
-  }
-
-  function confirmAdd() {
-    if (!addState || !addState.name.trim()) return;
-    const newStart = new Date(addState.startDate);
-    const newEnd   = new Date(addState.endDate);
-    if (isNaN(newStart.getTime()) || isNaN(newEnd.getTime()) || newStart > newEnd) return;
-
-    const col      = COLUMNS.find((c) => c.id === addState.columnId)!;
-    const initProg = col.dropProgress(0);
-    const newTask: Task = {
-      id:        genId(),
-      name:      addState.name.trim(),
-      startDate: newStart,
-      endDate:   newEnd,
-      progress:  initProg,
-      color:     addState.color,
-      ...(addState.parentId ? { parentId: addState.parentId } : {}),
-    };
-    onTasksChange([...tasks, newTask]);
-    setAddState(null);
   }
 
   // ── ドラッグ & ドロップ（列間移動 → 進捗更新）──
@@ -233,12 +206,7 @@ export default function KanbanBoard({ tasks, onTasksChange }: Props) {
                     style={{ borderLeftColor: task.color ?? "#4A90D9" }}
                   >
                     {/* 信号機インジケーター */}
-                    {(() => {
-                      const sig = getSignalStatus(task.id, tasks);
-                      if (sig === "none") return null;
-                      const title = sig === "red" ? "遅延" : sig === "yellow" ? "着手遅れ" : "正常";
-                      return <span className={`status-signal status-signal--${sig} kanban-card-signal`} title={title} />;
-                    })()}
+                    <SignalDot status={getSignalStatus(task.id, tasks)} className="kanban-card-signal" />
                     {/* 祖先パス */}
                     {ancestors.length > 0 && (
                       <div className="kanban-card-path">
@@ -305,62 +273,17 @@ export default function KanbanBoard({ tasks, onTasksChange }: Props) {
       })()}
 
       {/* ── 追加モーダル ── */}
-      {addState !== null && (
-        <div className="gantt-modal-overlay" onClick={() => setAddState(null)}>
-          <div className="gantt-modal" onClick={(e) => e.stopPropagation()}>
-            <h3>タスクを追加</h3>
-            <p className="modal-parent-info">
-              列: {COLUMNS.find((c) => c.id === addState.columnId)?.label}
-            </p>
-
-            <label className="modal-label">親タスク</label>
-            <select
-              className="assignee-input"
-              value={addState.parentId ?? ""}
-              onChange={(e) => setAddState({ ...addState, parentId: e.target.value || undefined })}
-            >
-              <option value="">なし（ルートタスク）</option>
-              {tasks
-                .filter((t) => !isLeaf(t.id, tasks))
-                .map((t) => (
-                  <option key={t.id} value={t.id}>{t.name}</option>
-                ))}
-            </select>
-
-            <label className="modal-label">タスク名 <span className="modal-required">*</span></label>
-            <input
-              type="text"
-              value={addState.name}
-              onChange={(e) => setAddState({ ...addState, name: e.target.value })}
-              placeholder="タスク名を入力"
-              className="assignee-input"
-              autoFocus
-              onKeyDown={(e) => { if (e.key === "Enter") confirmAdd(); }}
-            />
-
-            <div className="modal-date-row">
-              <div className="modal-date-field">
-                <label className="modal-label">開始日</label>
-                <input type="date" value={addState.startDate} max={addState.endDate} onChange={(e) => setAddState({ ...addState, startDate: e.target.value })} className="date-input" />
-              </div>
-              <div className="modal-date-field">
-                <label className="modal-label">終了日</label>
-                <input type="date" value={addState.endDate} min={addState.startDate} onChange={(e) => setAddState({ ...addState, endDate: e.target.value })} className="date-input" />
-              </div>
-            </div>
-
-            <div className="modal-color-row">
-              <label className="modal-label">カラー</label>
-              <input type="color" value={addState.color} onChange={(e) => setAddState({ ...addState, color: e.target.value })} className="color-input" />
-              <span className="modal-color-preview" style={{ background: addState.color }} />
-            </div>
-
-            <div className="gantt-modal-actions">
-              <button className="btn-cancel" onClick={() => setAddState(null)}>キャンセル</button>
-              <button className="btn-save" onClick={confirmAdd} disabled={!addState.name.trim()}>追加</button>
-            </div>
-          </div>
-        </div>
+      {addColumn !== null && (
+        <TaskAddModal
+          initialProgress={addColumn.initialProgress}
+          defaultParentId={addColumn.defaultParentId}
+          allTasks={tasks}
+          onConfirm={(newTask) => {
+            onTasksChange([...tasks, newTask]);
+            setAddColumn(null);
+          }}
+          onClose={() => setAddColumn(null)}
+        />
       )}
     </div>
   );

--- a/src/components/SignalDot.tsx
+++ b/src/components/SignalDot.tsx
@@ -1,0 +1,22 @@
+import { SignalStatus } from "../utils/taskUtils";
+
+const SIGNAL_TITLE: Record<Exclude<SignalStatus, "none">, string> = {
+  red:    "遅延",
+  yellow: "着手遅れ",
+  green:  "正常",
+};
+
+interface Props {
+  status: SignalStatus;
+  className?: string;
+}
+
+export default function SignalDot({ status, className }: Props) {
+  if (status === "none") return null;
+  return (
+    <span
+      className={`status-signal status-signal--${status}${className ? ` ${className}` : ""}`}
+      title={SIGNAL_TITLE[status]}
+    />
+  );
+}

--- a/src/components/TaskAddModal.tsx
+++ b/src/components/TaskAddModal.tsx
@@ -1,0 +1,117 @@
+import { useState } from "react";
+import { Task } from "../types/task";
+import { isLeaf, toInputDate, genId } from "../utils/taskUtils";
+
+function addDays(d: Date, n: number): Date {
+  const r = new Date(d);
+  r.setDate(r.getDate() + n);
+  return r;
+}
+
+interface Props {
+  parentTask?: Task;
+  initialProgress?: number;
+  defaultParentId?: string;
+  allTasks: Task[];
+  onConfirm: (task: Task) => void;
+  onClose: () => void;
+}
+
+export default function TaskAddModal({
+  parentTask,
+  initialProgress = 0,
+  defaultParentId,
+  allTasks,
+  onConfirm,
+  onClose,
+}: Props) {
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+
+  const [name,      setName]      = useState("");
+  const [startDate, setStartDate] = useState(toInputDate(today));
+  const [endDate,   setEndDate]   = useState(toInputDate(addDays(today, 6)));
+  const [color,     setColor]     = useState(parentTask?.color ?? "#4A90D9");
+  const [parentId,  setParentId]  = useState<string | undefined>(
+    parentTask?.id ?? defaultParentId
+  );
+
+  function handleConfirm() {
+    if (!name.trim()) return;
+    const newStart = new Date(startDate);
+    const newEnd   = new Date(endDate);
+    if (isNaN(newStart.getTime()) || isNaN(newEnd.getTime()) || newStart > newEnd) return;
+
+    const newTask: Task = {
+      id:        genId(),
+      name:      name.trim(),
+      startDate: newStart,
+      endDate:   newEnd,
+      progress:  initialProgress,
+      color,
+      ...(parentId ? { parentId } : {}),
+    };
+    onConfirm(newTask);
+  }
+
+  const title = parentTask ? "サブタスクを追加" : "タスクを追加";
+  const nonLeafTasks = allTasks.filter((t) => !isLeaf(t.id, allTasks));
+
+  return (
+    <div className="gantt-modal-overlay" onClick={onClose}>
+      <div className="gantt-modal" onClick={(e) => e.stopPropagation()}>
+        <h3>{title}</h3>
+        {parentTask && <p className="modal-parent-info">親タスク: {parentTask.name}</p>}
+
+        {!parentTask && (
+          <>
+            <label className="modal-label">親タスク</label>
+            <select
+              className="assignee-input"
+              value={parentId ?? ""}
+              onChange={(e) => setParentId(e.target.value || undefined)}
+            >
+              <option value="">なし（ルートタスク）</option>
+              {nonLeafTasks.map((t) => (
+                <option key={t.id} value={t.id}>{t.name}</option>
+              ))}
+            </select>
+          </>
+        )}
+
+        <label className="modal-label">タスク名 <span className="modal-required">*</span></label>
+        <input
+          type="text"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="タスク名を入力"
+          className="assignee-input"
+          autoFocus
+          onKeyDown={(e) => { if (e.key === "Enter") handleConfirm(); }}
+        />
+
+        <div className="modal-date-row">
+          <div className="modal-date-field">
+            <label className="modal-label">開始日</label>
+            <input type="date" value={startDate} max={endDate} onChange={(e) => setStartDate(e.target.value)} className="date-input" />
+          </div>
+          <div className="modal-date-field">
+            <label className="modal-label">終了日</label>
+            <input type="date" value={endDate} min={startDate} onChange={(e) => setEndDate(e.target.value)} className="date-input" />
+          </div>
+        </div>
+
+        <div className="modal-color-row">
+          <label className="modal-label">カラー</label>
+          <input type="color" value={color} onChange={(e) => setColor(e.target.value)} className="color-input" />
+          <span className="modal-color-preview" style={{ background: color }} />
+        </div>
+
+        <div className="gantt-modal-actions">
+          <button className="btn-cancel" onClick={onClose}>キャンセル</button>
+          <button className="btn-save" onClick={handleConfirm} disabled={!name.trim()}>追加</button>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- \`TaskAddModal.tsx\` を新規作成し、GanttChart / KanbanBoard の重複する追加モーダルJSXを共通化
- \`SignalDot.tsx\` を新規作成し、GanttLeftPanel のローカル \`SignalDot\` コンポーネントと KanbanBoard のインラインIIFEを統一
- GanttChart / KanbanBoard から \`AddState\` / \`confirmAdd\` を削除し \`TaskAddModal\` に委譲

## Test plan
- [ ] ガントチャートでルートタスクを追加できる
- [ ] ガントチャートでサブタスクを追加できる（親タスク名が表示される）
- [ ] カンバンボードの各列でタスクを追加できる（進捗が列に応じて設定される）
- [ ] 信号機インジケーターがガントチャート・カンバン両方で正しく表示される

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)