### PR TITLE
refactor: マジックナンバーの排除・命名の改善・軽微なUI挙動の修正（issue #21）

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -149,20 +149,13 @@ function App() {
         {loading && <div className="app-loading">読み込み中...</div>}
         {error   && <div className="app-error">エラー: {error}</div>}
 
-        {!loading && !error && isSearching && (
-          <SearchView
-            tasks={tasks}
-            query={searchQuery}
-          />
-        )}
-        {!loading && !error && !isSearching && viewMode === "gantt" && (
-          <GanttChart tasks={tasks} onTasksChange={handleTasksChange} holidays={holidays} />
-        )}
-        {!loading && !error && !isSearching && viewMode === "kanban" && (
-          <KanbanBoard tasks={tasks} onTasksChange={handleTasksChange} />
-        )}
-        {!loading && !error && !isSearching && viewMode === "analysis" && (
-          <AnalysisView tasks={tasks} />
+        {!loading && !error && (
+          <>
+            {isSearching && <SearchView tasks={tasks} query={searchQuery} />}
+            {!isSearching && viewMode === "gantt"     && <GanttChart tasks={tasks} onTasksChange={handleTasksChange} holidays={holidays} />}
+            {!isSearching && viewMode === "kanban"    && <KanbanBoard tasks={tasks} onTasksChange={handleTasksChange} />}
+            {!isSearching && viewMode === "analysis"  && <AnalysisView tasks={tasks} />}
+          </>
         )}
       </main>
     </div>

--- a/src/components/GanttLeftPanel.tsx
+++ b/src/components/GanttLeftPanel.tsx
@@ -1,6 +1,5 @@
 import { Task } from "../types/task";
-import { getSignalStatus, isLeaf, computeProgress } from "../utils/taskUtils";
-import { SignalStatus } from "../utils/taskUtils";
+import { getSignalStatus, computeProgress } from "../utils/taskUtils";
 
 const ROW_HEIGHT = 40;
 const HEADER_HEIGHT = 90;
@@ -133,7 +132,6 @@ export default function GanttLeftPanel({
           const depth         = getDepth(task.id, tasks);
           const hasChildren   = tasks.some((t) => t.parentId === task.id);
           const isCollapsed   = collapsedIds.has(task.id);
-          const leaf          = isLeaf(task.id, tasks);
           const effectiveProg = computeProgress(task.id, tasks);
           const expected      = expectedProgress(task, today);
           const isBehind      = effectiveProg < expected;
@@ -179,11 +177,11 @@ export default function GanttLeftPanel({
               >＋</button>
 
               <span
-                className={`gantt-col-assignee${leaf ? " gantt-col-assignee--leaf" : ""}`}
-                onClick={leaf ? () => onOpenEdit(task) : undefined}
-                title={leaf ? (task.assignee ? `担当: ${task.assignee}` : "クリックで担当者を設定") : undefined}
+                className={`gantt-col-assignee${!hasChildren ? " gantt-col-assignee--leaf" : ""}`}
+                onClick={!hasChildren ? () => onOpenEdit(task) : undefined}
+                title={!hasChildren ? (task.assignee ? `担当: ${task.assignee}` : "クリックで担当者を設定") : undefined}
               >
-                {leaf ? (
+                {!hasChildren ? (
                   task.assignee
                     ? <span className="assignee-badge">{task.assignee}</span>
                     : <span className="assignee-empty">未設定</span>

--- a/src/components/GanttTimeline.tsx
+++ b/src/components/GanttTimeline.tsx
@@ -150,8 +150,8 @@ export default function GanttTimeline({
 
           const barLeft  = diffDays(rangeStart, barStart) * DAY_WIDTH;
           const barWidth = Math.max((diffDays(barStart, barEnd) + 1) * DAY_WIDTH, DAY_WIDTH);
-          const ep        = computeProgress(task.id, tasks);
-          const done      = ep === 100;
+          const effectiveProg = computeProgress(task.id, tasks);
+          const done          = effectiveProg === 100;
           const baseColor = done ? "#999" : (task.color ?? "#4A90D9");
           const barColor  = `${baseColor}${barOpacity(depth)}`;
           const barHeight = Math.max(14, ROW_HEIGHT - depth * 4 - 18);
@@ -185,12 +185,12 @@ export default function GanttTimeline({
                 style={{ left: barLeft, width: barWidth, height: barHeight, background: barColor, cursor: "grab", userSelect: "none" }}
                 onMouseDown={(e) => onStartDrag(e, task, "move")}
                 onClick={() => { if (!didDragRef.current) onOpenEdit(task); }}
-                onMouseEnter={(e) => { if (!dragPreview) onSetTooltip({ task, progress: ep, x: e.clientX, y: e.clientY }); }}
-                onMouseMove={(e)  => { if (!dragPreview) onSetTooltip({ task, progress: ep, x: e.clientX, y: e.clientY }); }}
+                onMouseEnter={(e) => { if (!dragPreview) onSetTooltip({ task, progress: effectiveProg, x: e.clientX, y: e.clientY }); }}
+                onMouseMove={(e)  => { if (!dragPreview) onSetTooltip({ task, progress: effectiveProg, x: e.clientX, y: e.clientY }); }}
                 onMouseLeave={() => onSetTooltip(null)}
               >
                 <div className="gantt-bar-handle gantt-bar-handle--left" style={{ width: HANDLE_WIDTH }} onMouseDown={(e) => onStartDrag(e, task, "start")} />
-                <div className="gantt-bar-progress" style={{ width: `${ep}%`, background: baseColor, filter: "brightness(0.75)" }} />
+                <div className="gantt-bar-progress" style={{ width: `${effectiveProg}%`, background: baseColor, filter: "brightness(0.75)" }} />
                 <span className="gantt-bar-label">{task.name}</span>
                 <div className="gantt-bar-handle gantt-bar-handle--right" style={{ width: HANDLE_WIDTH }} onMouseDown={(e) => onStartDrag(e, task, "end")} />
               </div>

--- a/src/components/KanbanBoard.tsx
+++ b/src/components/KanbanBoard.tsx
@@ -15,6 +15,12 @@ function formatDateShort(d: Date): string {
   return `${d.getMonth() + 1}/${d.getDate()}`;
 }
 
+function addDays(d: Date, n: number): Date {
+  const r = new Date(d);
+  r.setDate(r.getDate() + n);
+  return r;
+}
+
 // ── カラム定義 ────────────────────────────────────────────
 
 interface Column {
@@ -112,7 +118,7 @@ export default function KanbanBoard({ tasks, onTasksChange }: Props) {
       columnId,
       name:      "",
       startDate: toInputDate(today),
-      endDate:   toInputDate(new Date(today.getTime() + 6 * 86400000)),
+      endDate:   toInputDate(addDays(today, 6)),
       color:     "#4A90D9",
       parentId:  filterParentId === "all" ? undefined : filterParentId,
     });

--- a/src/components/TaskEditModal.tsx
+++ b/src/components/TaskEditModal.tsx
@@ -22,8 +22,7 @@ interface Props {
 }
 
 export default function TaskEditModal({ task, tasks, onSave, onDelete, onClose }: Props) {
-  const leaf        = isLeaf(task.id, tasks);
-  const hasChildren = tasks.some((t) => t.parentId === task.id);
+  const leaf = isLeaf(task.id, tasks);
 
   const [editName,      setEditName]      = useState(task.name);
   const [editProgress,  setEditProgress]  = useState(task.progress);
@@ -63,7 +62,7 @@ export default function TaskEditModal({ task, tasks, onSave, onDelete, onClose }
   }
 
   return (
-    <div className="gantt-modal-overlay" onClick={handleSave}>
+    <div className="gantt-modal-overlay" onClick={onClose}>
       <div className="gantt-modal" onClick={(e) => e.stopPropagation()}>
         <input
           type="text"
@@ -126,7 +125,7 @@ export default function TaskEditModal({ task, tasks, onSave, onDelete, onClose }
           {confirmDelete ? (
             <>
               <span className="modal-delete-confirm">
-                {hasChildren ? "子タスクも全て削除します。よろしいですか？" : "削除しますか？"}
+                {!leaf ? "子タスクも全て削除します。よろしいですか？" : "削除しますか？"}
               </span>
               <button className="btn-cancel" onClick={() => setConfirmDelete(false)}>いいえ</button>
               <button className="btn-delete" onClick={handleDelete}>削除する</button>


### PR DESCRIPTION
## Summary
- \`KanbanBoard.tsx\`: マジックナンバー \`86400000\` を \`addDays(today, 6)\` に置換
- \`GanttTimeline.tsx\`: 変数名 \`ep\` を \`effectiveProg\` にリネームし左パネルと統一
- \`GanttLeftPanel.tsx\`: \`leaf\` と \`hasChildren\` の冗長な共存を解消（\`hasChildren\` に統一）
- \`TaskEditModal.tsx\`: 同上（\`leaf\` に統一）＋オーバーレイクリックを \`handleSave\` → \`onClose\` に修正
- \`App.tsx\`: \`!loading && !error\` の4回繰り返しを外側のガード節にまとめて排除

## Test plan
- [ ] カンバンボードでタスク追加時のデフォルト終了日が今日+6日になっている
- [ ] TaskEditModal でオーバーレイをクリックするとモーダルが閉じる（保存されない）
- [ ] 全ビューで読み込み・エラー状態が正しく表示される

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)