### PR TITLE
fix: タスクが0件のときGanttTimelineがクラッシュする問題を修正

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5312,7 +5312,7 @@ dependencies = [
 
 [[package]]
 name = "wbs"
-version = "0.1.0"
+version = "1.0.9"
 dependencies = [
  "backtrace",
  "chrono",

--- a/src/components/GanttTimeline.tsx
+++ b/src/components/GanttTimeline.tsx
@@ -82,6 +82,14 @@ export default function GanttTimeline({
   const allDates = tasks.flatMap((t) => [t.startDate, t.endDate]);
   if (dragPreview) allDates.push(dragPreview.startDate, dragPreview.endDate);
 
+  if (allDates.length === 0) {
+    return (
+      <div className="gantt-timeline-wrapper gantt-timeline-empty">
+        <span>表示するタスクがありません</span>
+      </div>
+    );
+  }
+
   const minDate    = allDates.reduce((m, d) => (d < m ? d : m));
   const maxDate    = allDates.reduce((m, d) => (d > m ? d : m));
   const rangeStart = addDays(minDate, -1);

--- a/src/styles.css
+++ b/src/styles.css
@@ -326,6 +326,13 @@
 }
 
 /* ── Timeline ── */
+.gantt-timeline-wrapper.gantt-timeline-empty {
+  align-items: center;
+  justify-content: center;
+  color: #888;
+  font-size: 0.95rem;
+}
+
 .gantt-timeline-wrapper {
   flex: 1;
   overflow-x: auto;


### PR DESCRIPTION
## Summary

- タスクを全削除した状態でガントチャートを表示すると `Reduce of empty array with no initial value` エラーが発生しクラッシュしていた問題を修正
- `allDates` が空の場合に早期リターンし、「表示するタスクがありません」メッセージを表示するよう対応
- 空状態用の CSS クラス `.gantt-timeline-empty` を追加

## Root Cause

`GanttTimeline.tsx` の `allDates.reduce()` が初期値なしで呼ばれており、タスク0件（空配列）のときに例外が発生していた。

## Test plan

- [x] タスクを全て削除した状態でガントチャートを開き、クラッシュせず「表示するタスクがありません」が表示されることを確認
- [x] タスクが1件以上ある場合は従来通りガントチャートが正常表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)