### PR TITLE
feat: tasks.json の取り込み（インポート）機能を追加

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -152,6 +152,31 @@ fn build_client(proxy_url: Option<String>) -> Result<reqwest::Client, String> {
     builder.build().map_err(|e| e.to_string())
 }
 
+// ── タスク JSON インポート ────────────────────────────────
+
+/// ファイル選択ダイアログを表示し、選択された JSON ファイルの内容を返す。
+/// キャンセル時は Ok(None) を返す。
+#[tauri::command]
+async fn import_tasks_file(app: tauri::AppHandle) -> Result<Option<String>, String> {
+    use tauri_plugin_dialog::DialogExt;
+
+    let path = app
+        .dialog()
+        .file()
+        .add_filter("JSON ファイル", &["json"])
+        .blocking_pick_file();
+
+    match path {
+        None => Ok(None),
+        Some(p) => {
+            let path_str = p.to_string();
+            fs::read_to_string(&path_str)
+                .map(Some)
+                .map_err(|e| format!("ファイルの読み込みに失敗: {e}"))
+        }
+    }
+}
+
 // ── Excel ファイル保存 ────────────────────────────────────
 
 /// 名前を付けて保存ダイアログを表示し、選択されたパスに Excel バイト列を書き込む。
@@ -207,6 +232,7 @@ pub fn run() {
             get_proxy_setting,
             save_proxy_setting,
             save_excel_file,
+            import_tasks_file,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,7 +6,7 @@ import AnalysisView      from "./components/AnalysisView";
 import ProxySettingModal from "./components/ProxySettingModal";
 import UpdateNotifier    from "./components/UpdateNotifier";
 import { Task }       from "./types/task";
-import { loadTasks, saveTasks } from "./utils/taskStorage";
+import { loadTasks, saveTasks, importTasksFromFile } from "./utils/taskStorage";
 import { loadHolidays }         from "./utils/holidays";
 import { sortByTree }           from "./utils/taskUtils";
 import { exportToExcel }        from "./utils/exportToExcel";
@@ -23,6 +23,7 @@ function App() {
   const [searchQuery, setSearchQuery] = useState("");
   const [showProxy,    setShowProxy]    = useState(false);
   const [exportMsg,    setExportMsg]    = useState<{ text: string; isError: boolean } | null>(null);
+  const [importMsg,    setImportMsg]    = useState<{ text: string; isError: boolean } | null>(null);
   const searchRef = useRef<HTMLInputElement>(null);
 
   // 起動時: タスク（保存済み or デフォルト）と祝日を並列ロード
@@ -126,6 +127,33 @@ function App() {
           </button>
         </div>
 
+        {/* JSON インポートボタン */}
+        <button
+          className="app-import-btn"
+          onClick={() => {
+            importTasksFromFile()
+              .then((imported) => {
+                if (imported === null) return; // キャンセル
+                const importedMap = new Map(imported.map((t) => [t.id, t]));
+                // 既存タスクを上書き更新 → 新規タスクを末尾に追加
+                const merged = [
+                  ...tasks.map((t) => importedMap.get(t.id) ?? t),
+                  ...imported.filter((t) => !tasks.some((cur) => cur.id === t.id)),
+                ];
+                handleTasksChange(merged);
+                setImportMsg({ text: `${imported.length} 件のタスクをマージしました`, isError: false });
+                setTimeout(() => setImportMsg(null), 5000);
+              })
+              .catch((e) => {
+                setImportMsg({ text: `インポート失敗: ${e}`, isError: true });
+                setTimeout(() => setImportMsg(null), 6000);
+              });
+          }}
+          title="tasks.json を取り込む"
+        >
+          📂 取り込み
+        </button>
+
         {/* Excel エクスポートボタン */}
         <button
           className="app-excel-btn"
@@ -158,6 +186,13 @@ function App() {
       </header>
 
       {showProxy && <ProxySettingModal onClose={() => setShowProxy(false)} />}
+
+      {importMsg && (
+        <div className={`toast ${importMsg.isError ? "toast--warn" : "toast--ok"}`}>
+          {importMsg.isError ? "⚠️" : "✅"} {importMsg.text}
+          <button className="toast-close" onClick={() => setImportMsg(null)}>✕</button>
+        </div>
+      )}
 
       {exportMsg && (
         <div className={`toast ${exportMsg.isError ? "toast--warn" : "toast--ok"}`}>

--- a/src/styles.css
+++ b/src/styles.css
@@ -29,6 +29,23 @@
   flex-shrink: 0;
 }
 
+.app-import-btn {
+  background: none;
+  border: 1px solid rgba(255,255,255,0.2);
+  color: #ccc;
+  font-size: 0.78rem;
+  cursor: pointer;
+  padding: 4px 10px;
+  border-radius: 6px;
+  transition: color 0.15s, background 0.15s, border-color 0.15s;
+  flex-shrink: 0;
+  white-space: nowrap;
+}
+.app-import-btn:hover {
+  color: #fff;
+  background: rgba(255,255,255,0.12);
+  border-color: rgba(255,255,255,0.45);
+}
 .app-excel-btn {
   margin-left: auto;
   background: none;

--- a/src/utils/taskStorage.ts
+++ b/src/utils/taskStorage.ts
@@ -53,6 +53,19 @@ export async function loadTasks(): Promise<Task[]> {
   return loadSampleTasks();
 }
 
+// ── インポート ──────────────────────────────────────────────
+
+/**
+ * ファイル選択ダイアログを開き、選択された tasks.json を読み込んで Task[] を返す。
+ * キャンセル時は null を返す。
+ */
+export async function importTasksFromFile(): Promise<Task[] | null> {
+  const json = await invoke<string | null>("import_tasks_file");
+  if (json === null) return null;
+  const raws: TaskRaw[] = JSON.parse(json);
+  return raws.map(toTask);
+}
+
 // ── 保存 ────────────────────────────────────────────────────
 
 /**


### PR DESCRIPTION
## Summary

- ヘッダーに「📂 取り込み」ボタンを追加し、他ユーザーの `tasks.json` をファイルダイアログで選択して取り込めるようにした
- Tauri コマンド `import_tasks_file` を追加（JSON ファイル選択 → 読み込み）
- マージ処理: ID 一致タスクは相手版で上書き、新規タスクは末尾に追加、自分のみのタスクは保持
- 取り込み結果はトースト通知で表示

## 関連 Issue

同一タスクの同定ロジックについては #33 で継続検討。

## Test plan

- [ ] 「📂 取り込み」ボタンをクリックするとファイルダイアログが開く
- [ ] キャンセル時は何も変化しない
- [ ] 同一ベースの tasks.json を取り込むと、相手の変更がマージされる
- [ ] 自分が追加したタスク（相手のファイルにない ID）は消えない
- [ ] 相手が追加したタスク（自分にない ID）が末尾に追加される
- [ ] JSON パースエラー時はエラートーストが表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)