### PR TITLE
feat: issue #35/#36/#37 対応（サブメンバー・Excel1日バグ修正・KanbanカラーIR継承）

### DIFF
--- a/src/components/GanttLeftPanel.tsx
+++ b/src/components/GanttLeftPanel.tsx
@@ -184,12 +184,21 @@ export default function GanttLeftPanel({
               <span
                 className={`gantt-col-assignee${!hasChildren ? " gantt-col-assignee--leaf" : ""}`}
                 onClick={!hasChildren ? () => onOpenEdit(task) : undefined}
-                title={!hasChildren ? (task.assignee ? `担当: ${task.assignee}` : "クリックで担当者を設定") : undefined}
+                title={!hasChildren
+                  ? [task.assignee, ...(task.subMembers ?? [])].filter(Boolean).join(", ") || "クリックで担当者を設定"
+                  : undefined}
               >
                 {!hasChildren ? (
-                  task.assignee
-                    ? <span className="assignee-badge">{task.assignee}</span>
-                    : <span className="assignee-empty">未設定</span>
+                  task.assignee ? (
+                    <span className="assignee-badge">
+                      {task.assignee}
+                      {task.subMembers && task.subMembers.length > 0 && (
+                        <span className="sub-members-count"> +{task.subMembers.length}</span>
+                      )}
+                    </span>
+                  ) : (
+                    <span className="assignee-empty">未設定</span>
+                  )
                 ) : (
                   <span className="assignee-empty">─</span>
                 )}

--- a/src/components/KanbanBoard.tsx
+++ b/src/components/KanbanBoard.tsx
@@ -97,7 +97,11 @@ export default function KanbanBoard({ tasks, onTasksChange }: Props) {
   const rootTasks = tasks.filter((t) => !t.parentId);
 
   // 担当者一覧（重複除去）
-  const assignees = [...new Set(tasks.map((t) => t.assignee).filter(Boolean))] as string[];
+  const assignees = [
+    ...new Set(
+      tasks.flatMap((t) => [t.assignee, ...(t.subMembers ?? [])]).filter(Boolean)
+    ),
+  ] as string[];
 
   // フィルタ適用
   const filteredByParent = filterParentId === "all"
@@ -105,7 +109,9 @@ export default function KanbanBoard({ tasks, onTasksChange }: Props) {
     : leafTasks.filter((t) => getAllDescendantIds(filterParentId, tasks).includes(t.id));
 
   const visibleTasks = filteredByParent.filter((t) =>
-    filterAssignee === "all" || t.assignee === filterAssignee
+    filterAssignee === "all" ||
+    t.assignee === filterAssignee ||
+    (t.subMembers ?? []).includes(filterAssignee)
   );
 
   function openEdit(task: Task) {
@@ -114,12 +120,16 @@ export default function KanbanBoard({ tasks, onTasksChange }: Props) {
 
   function openAdd(columnId: Column["id"]) {
     const today = new Date();
+    const parent = filterParentId !== "all"
+      ? tasks.find((t) => t.id === filterParentId)
+      : undefined;
+    const defaultColor = parent?.color ?? "#4A90D9";
     setAddState({
       columnId,
       name:      "",
       startDate: toInputDate(today),
       endDate:   toInputDate(addDays(today, 6)),
-      color:     "#4A90D9",
+      color:     defaultColor,
       parentId:  filterParentId === "all" ? undefined : filterParentId,
     });
   }
@@ -279,7 +289,17 @@ export default function KanbanBoard({ tasks, onTasksChange }: Props) {
                         {formatDateShort(task.startDate)} – {formatDateShort(task.endDate)}
                       </span>
                       {task.assignee && (
-                        <span className="kanban-card-assignee">{task.assignee}</span>
+                        <span
+                          className="kanban-card-assignee"
+                          title={task.subMembers && task.subMembers.length > 0
+                            ? `${task.assignee} / ${task.subMembers.join(", ")}`
+                            : task.assignee}
+                        >
+                          {task.assignee}
+                          {task.subMembers && task.subMembers.length > 0 && (
+                            <span className="sub-members-count"> +{task.subMembers.length}</span>
+                          )}
+                        </span>
                       )}
                       <span className="kanban-card-pct">{progress}%</span>
                     </div>
@@ -323,7 +343,11 @@ export default function KanbanBoard({ tasks, onTasksChange }: Props) {
             <select
               className="assignee-input"
               value={addState.parentId ?? ""}
-              onChange={(e) => setAddState({ ...addState, parentId: e.target.value || undefined })}
+              onChange={(e) => {
+                const parentId = e.target.value || undefined;
+                const parent = parentId ? tasks.find((t) => t.id === parentId) : undefined;
+                setAddState({ ...addState, parentId, color: parent?.color ?? "#4A90D9" });
+              }}
             >
               <option value="">なし（ルートタスク）</option>
               {tasks

--- a/src/components/TaskEditModal.tsx
+++ b/src/components/TaskEditModal.tsx
@@ -24,12 +24,14 @@ interface Props {
 export default function TaskEditModal({ task, tasks, onSave, onDelete, onClose }: Props) {
   const leaf = isLeaf(task.id, tasks);
 
-  const [editName,      setEditName]      = useState(task.name);
-  const [editProgress,  setEditProgress]  = useState(task.progress);
-  const [editAssignee,  setEditAssignee]  = useState(task.assignee  ?? "");
-  const [editStartDate, setEditStartDate] = useState(toInputDate(task.startDate));
-  const [editEndDate,   setEditEndDate]   = useState(toInputDate(task.endDate));
-  const [editMemo,      setEditMemo]      = useState(task.memo ?? "");
+  const [editName,        setEditName]        = useState(task.name);
+  const [editProgress,    setEditProgress]    = useState(task.progress);
+  const [editAssignee,    setEditAssignee]    = useState(task.assignee    ?? "");
+  const [editSubMembers,  setEditSubMembers]  = useState<string[]>(task.subMembers ?? []);
+  const [newSubMember,    setNewSubMember]    = useState("");
+  const [editStartDate,   setEditStartDate]   = useState(toInputDate(task.startDate));
+  const [editEndDate,     setEditEndDate]     = useState(toInputDate(task.endDate));
+  const [editMemo,        setEditMemo]        = useState(task.memo ?? "");
   const [confirmDelete, setConfirmDelete] = useState(false);
   const initialMode = task.progressCount ? "count" : "percent";
   const [progressMode,  setProgressMode]  = useState<"percent" | "count">(initialMode);
@@ -79,6 +81,7 @@ export default function TaskEditModal({ task, tasks, onSave, onDelete, onClose }
             name:          editName.trim() || task.name,
             progress:      editProgress,
             assignee:      editAssignee  || undefined,
+            subMembers:    editSubMembers.length > 0 ? editSubMembers : undefined,
             startDate:     newStart,
             endDate:       newEnd,
             memo:          editMemo      || undefined,
@@ -121,7 +124,7 @@ export default function TaskEditModal({ task, tasks, onSave, onDelete, onClose }
         {/* 担当者（リーフのみ） */}
         {leaf && (
           <>
-            <label className="modal-label">担当者</label>
+            <label className="modal-label">担当者（主）</label>
             <input
               type="text"
               value={editAssignee}
@@ -129,6 +132,47 @@ export default function TaskEditModal({ task, tasks, onSave, onDelete, onClose }
               placeholder="担当者名を入力"
               className="assignee-input"
             />
+
+            <label className="modal-label">サブメンバー</label>
+            {editSubMembers.length > 0 && (
+              <div className="sub-members-list">
+                {editSubMembers.map((member, idx) => (
+                  <div key={idx} className="sub-member-item">
+                    <span className="sub-member-name">{member}</span>
+                    <button
+                      className="sub-member-remove"
+                      onClick={() => setEditSubMembers(editSubMembers.filter((_, i) => i !== idx))}
+                      title="削除"
+                    >×</button>
+                  </div>
+                ))}
+              </div>
+            )}
+            <div className="sub-member-add-row">
+              <input
+                type="text"
+                value={newSubMember}
+                onChange={(e) => setNewSubMember(e.target.value)}
+                placeholder="メンバー名を入力"
+                className="assignee-input sub-member-input"
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" && newSubMember.trim()) {
+                    setEditSubMembers([...editSubMembers, newSubMember.trim()]);
+                    setNewSubMember("");
+                  }
+                }}
+              />
+              <button
+                className="btn-add-member"
+                onClick={() => {
+                  if (newSubMember.trim()) {
+                    setEditSubMembers([...editSubMembers, newSubMember.trim()]);
+                    setNewSubMember("");
+                  }
+                }}
+                disabled={!newSubMember.trim()}
+              >＋ 追加</button>
+            </div>
           </>
         )}
 

--- a/src/hooks/useGanttFilter.ts
+++ b/src/hooks/useGanttFilter.ts
@@ -6,7 +6,11 @@ export function useGanttFilter(tasks: Task[]) {
   const [filterParentId, setFilterParentId] = useState<string>("all");
   const [filterAssignee, setFilterAssignee] = useState<string>("all");
 
-  const assignees = [...new Set(tasks.map((t) => t.assignee).filter(Boolean))] as string[];
+  const assignees = [
+    ...new Set(
+      tasks.flatMap((t) => [t.assignee, ...(t.subMembers ?? [])]).filter(Boolean)
+    ),
+  ] as string[];
 
   const filteredByParent =
     filterParentId === "all"
@@ -24,9 +28,13 @@ export function useGanttFilter(tasks: Task[]) {
       : filteredByParent.filter(
           (t) =>
             t.assignee === filterAssignee ||
+            (t.subMembers ?? []).includes(filterAssignee) ||
             getAllDescendantIds(t.id, tasks)
               .slice(1)
-              .some((id) => tasks.find((c) => c.id === id)?.assignee === filterAssignee)
+              .some((id) => {
+                const c = tasks.find((c) => c.id === id);
+                return c?.assignee === filterAssignee || (c?.subMembers ?? []).includes(filterAssignee);
+              })
         );
 
   function resetParentFilter(value: string) {

--- a/src/styles.css
+++ b/src/styles.css
@@ -1999,3 +1999,81 @@
   height: 12px;
   margin-right: 0;
 }
+
+/* ── サブメンバー ───────────────────────────────────── */
+
+.sub-members-count {
+  font-size: 0.68rem;
+  color: #7b97c2;
+  font-weight: 400;
+}
+
+.sub-members-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin-bottom: 6px;
+}
+
+.sub-member-item {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  background: #f0f4fb;
+  border: 1px solid #c8d6ea;
+  border-radius: 12px;
+  padding: 2px 8px 2px 10px;
+  font-size: 0.8rem;
+  color: #374151;
+}
+
+.sub-member-name {
+  white-space: nowrap;
+}
+
+.sub-member-remove {
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: #9ca3af;
+  font-size: 0.9rem;
+  padding: 0;
+  line-height: 1;
+  display: flex;
+  align-items: center;
+}
+
+.sub-member-remove:hover {
+  color: #ef4444;
+}
+
+.sub-member-add-row {
+  display: flex;
+  gap: 6px;
+  align-items: center;
+}
+
+.sub-member-input {
+  flex: 1;
+}
+
+.btn-add-member {
+  background: #4a90d9;
+  color: #fff;
+  border: none;
+  border-radius: 6px;
+  padding: 6px 12px;
+  font-size: 0.82rem;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background 0.2s;
+}
+
+.btn-add-member:hover:not(:disabled) {
+  background: #3070b8;
+}
+
+.btn-add-member:disabled {
+  background: #b0c4de;
+  cursor: not-allowed;
+}

--- a/src/types/task.ts
+++ b/src/types/task.ts
@@ -8,6 +8,7 @@ export interface Task {
   parentId?: string;
   collapsed?: boolean;
   assignee?: string;
+  subMembers?: string[];
   memo?: string;
   progressCount?: { done: number; total: number };
 }

--- a/src/utils/exportToExcel.ts
+++ b/src/utils/exportToExcel.ts
@@ -164,7 +164,12 @@ export async function exportToExcel(tasks: Task[], filename?: string): Promise<s
 
     // 担当者
     const ac = exRow.getCell(2);
-    ac.value     = task.assignee ?? "";
+    const subMembersStr = task.subMembers && task.subMembers.length > 0
+      ? task.subMembers.join(", ")
+      : "";
+    ac.value     = task.assignee
+      ? (subMembersStr ? `${task.assignee} / ${subMembersStr}` : task.assignee)
+      : subMembersStr;
     ac.font      = { size: 9 };
     ac.fill      = solidFill(rowBg);
     ac.alignment = { horizontal: "center", vertical: "middle" };
@@ -202,8 +207,10 @@ export async function exportToExcel(tasks: Task[], filename?: string): Promise<s
     sc2.border    = { bottom: THIN_BORDER, right: { style: "medium", color: { argb: "FFB0BEC5" } } };
 
     // ── ガントバー ─────────────────────────────────────
-    const tStart  = task.startDate.getTime();
-    const tEnd    = task.endDate.getTime();
+    const _tS = new Date(task.startDate); _tS.setHours(0, 0, 0, 0);
+    const _tE = new Date(task.endDate);   _tE.setHours(0, 0, 0, 0);
+    const tStart  = _tS.getTime();
+    const tEnd    = _tE.getTime();
     const doneMs  = (tEnd - tStart) * (progress / 100);
     const barDone = colorArgb;                           // 完了部分 = タスク色
     const barTodo = lightenHex("#" + colorHex, 0.55);   // 未完了 = 薄い色

--- a/src/utils/taskStorage.ts
+++ b/src/utils/taskStorage.ts
@@ -14,6 +14,7 @@ interface TaskRaw {
   color?: string;
   parentId?: string;
   assignee?: string;
+  subMembers?: string[];
   progressCount?: { done: number; total: number };
 }
 


### PR DESCRIPTION
## Summary

- **#35 サブメンバー（複数担当者）対応**
  - `Task` 型に `subMembers?: string[]` を追加（`assignee` は後方互換で維持）
  - `TaskEditModal` にサブメンバー追加・削除UI実装（Enter or ボタンで追加、×で削除）
  - `GanttLeftPanel` で担当者バッジに `+N` 短縮表示、ホバーでフルリスト
  - `KanbanBoard` カードでサブメンバー数表示 & ホバーで全員名
  - 担当者フィルター（GanttChart・KanbanBoard両方）をサブメンバーにも対応
  - Excel出力の担当者列を `主担当者 / サブA, サブB` 形式で出力

- **#36 Excel出力: 1日タスクのガントバー塗り分けバグ修正**
  - `tStart`/`tEnd` の時刻成分をゼロ化し、`days` 配列の各要素と同一基準で比較するよう修正

- **#37 KanbanBoard タスク追加時に親カラーを引き継ぐ**
  - `openAdd()` で `filterParentId` から親タスクを検索してデフォルトカラーを設定
  - 追加モーダル内の親タスクセレクト変更時もカラーを連動更新

## Test plan

- [ ] リーフタスク編集モーダルでサブメンバーを追加・削除できること
- [ ] GanttChart の担当者列にサブメンバー数（+N）が表示され、ホバーでフルリストが出ること
- [ ] KanbanBoard カードのフッターにサブメンバー数が表示され、ホバーで全員名が出ること
- [ ] 担当者フィルターにサブメンバーが選択肢として表示され、絞り込みが効くこと
- [ ] Excel出力で担当者列に `主 / サブA, サブB` 形式で出力されること
- [ ] 開始日＝終了日の1日タスクをExcel出力したときにガントバーセルが塗られること
- [ ] KanbanBoard で親タスクフィルター選択後に「＋」でタスク追加すると親カラーが初期値になること
- [ ] 追加モーダル内で親タスクを切り替えるとカラーが連動すること
- [ ] 既存データ（subMembers未定義）を開いても正常動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)