### PR TITLE
feat: issue #40/#41/#42 対応

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4571,6 +4571,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-window-state"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73736611e14142408d15353e21e3cca2f12a3cfb523ad0ce85999b6d2ef1a704"
+dependencies = [
+ "bitflags 2.11.0",
+ "log",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "tauri-runtime"
 version = "2.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5391,6 +5406,7 @@ dependencies = [
  "tauri-plugin-opener",
  "tauri-plugin-process",
  "tauri-plugin-updater",
+ "tauri-plugin-window-state",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -18,6 +18,7 @@ tauri-build = { version = "2", features = [] }
 
 [dependencies]
 tauri = { version = "2", features = [] }
+tauri-plugin-window-state = "2"
 tauri-plugin-dialog = "2"
 tauri-plugin-opener = "2"
 tauri-plugin-updater = "2"

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -8,6 +8,9 @@
     "opener:default",
     "updater:default",
     "process:allow-restart",
-    "log:default"
+    "log:default",
+    "window-state:allow-filename",
+    "window-state:allow-restore-state",
+    "window-state:allow-save-window-state"
   ]
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -195,6 +195,7 @@ async fn save_excel_file(
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()
+        .plugin(tauri_plugin_window_state::Builder::new().build())
         .plugin(tauri_plugin_log::Builder::new().build())
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_opener::init())

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -14,7 +14,8 @@
       {
         "title": "WBS 進捗管理",
         "width": 1024,
-        "height": 768
+        "height": 768,
+        "dragDropEnabled": false
       }
     ],
     "security": {

--- a/src/components/GanttTimeline.tsx
+++ b/src/components/GanttTimeline.tsx
@@ -9,6 +9,36 @@ const ROW_HEIGHT = 40;
 const HEADER_HEIGHT = 90;
 const HANDLE_WIDTH = 6;
 
+function getLuminance(hexColor: string): number {
+  const r = parseInt(hexColor.slice(1, 3), 16) / 255;
+  const g = parseInt(hexColor.slice(3, 5), 16) / 255;
+  const b = parseInt(hexColor.slice(5, 7), 16) / 255;
+  const toLinear = (c: number) =>
+    c <= 0.04045 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4);
+  return 0.2126 * toLinear(r) + 0.7152 * toLinear(g) + 0.0722 * toLinear(b);
+}
+
+/** CSS brightness(factor) フィルターを近似してRGB各チャンネルを乗算した16進カラーを返す */
+function applyBrightness(hexColor: string, factor: number): string {
+  const clamp = (v: number) => Math.min(255, Math.max(0, Math.round(v)));
+  const r = clamp(parseInt(hexColor.slice(1, 3), 16) * factor);
+  const g = clamp(parseInt(hexColor.slice(3, 5), 16) * factor);
+  const b = clamp(parseInt(hexColor.slice(5, 7), 16) * factor);
+  return `#${r.toString(16).padStart(2, "0")}${g.toString(16).padStart(2, "0")}${b.toString(16).padStart(2, "0")}`;
+}
+
+/**
+ * バー上のテキスト色を返す。
+ * 進捗オーバーレイ（brightness 0.75）と素のバー背景の
+ * 両方に対してコントラストが取れるよう、暗い方の色で判定する。
+ */
+function getContrastTextColor(baseColor: string): string {
+  const progressColor = applyBrightness(baseColor, 0.75);
+  // 進捗部分の方が常に暗いため、そちらで判定すれば非進捗部分も担保される
+  const luminance = getLuminance(progressColor);
+  return luminance > 0.179 ? "#000000" : "#ffffff";
+}
+
 function diffDays(a: Date, b: Date): number {
   return Math.round((b.getTime() - a.getTime()) / (1000 * 60 * 60 * 24));
 }
@@ -162,6 +192,7 @@ export default function GanttTimeline({
           const done          = effectiveProg === 100;
           const baseColor = done ? "#999" : (task.color ?? "#4A90D9");
           const barColor  = `${baseColor}${barOpacity(depth)}`;
+          const textColor = getContrastTextColor(baseColor);
           const barHeight = Math.max(14, ROW_HEIGHT - depth * 4 - 18);
 
           return (
@@ -199,7 +230,7 @@ export default function GanttTimeline({
               >
                 <div className="gantt-bar-handle gantt-bar-handle--left" style={{ width: HANDLE_WIDTH }} onMouseDown={(e) => onStartDrag(e, task, "start")} />
                 <div className="gantt-bar-progress" style={{ width: `${effectiveProg}%`, background: baseColor, filter: "brightness(0.75)" }} />
-                <span className="gantt-bar-label">{task.name}</span>
+                <span className="gantt-bar-label" style={{ color: textColor }}>{task.name}</span>
                 <div className="gantt-bar-handle gantt-bar-handle--right" style={{ width: HANDLE_WIDTH }} onMouseDown={(e) => onStartDrag(e, task, "end")} />
               </div>
             </div>

--- a/src/components/GanttTooltip.tsx
+++ b/src/components/GanttTooltip.tsx
@@ -1,6 +1,7 @@
 /**
  * GanttTooltip – ガントバーのホバーツールチップ（Markdownメモ対応）
  */
+import { useRef, useLayoutEffect, useState } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm    from "remark-gfm";
 import { Task } from "../types/task";
@@ -17,12 +18,21 @@ function fmtDate(d: Date): string {
 }
 
 export default function GanttTooltip({ task, progress, x, y }: Props) {
+  const ref = useRef<HTMLDivElement>(null);
+  const [top, setTop] = useState(y + 18);
+
+  useLayoutEffect(() => {
+    if (!ref.current) return;
+    const height = ref.current.offsetHeight;
+    const overflow = y + 18 + height > window.innerHeight;
+    setTop(overflow ? Math.max(y - height - 8, 4) : y + 18);
+  }, [y, task]);
+
   // 画面右端に近い場合は左側に表示
-  const left = Math.min(x + 14, window.innerWidth  - 340);
-  const top  = Math.min(y + 18, window.innerHeight - 40);
+  const left = Math.min(x + 14, window.innerWidth - 340);
 
   return (
-    <div className="gantt-tooltip" style={{ left, top }}>
+    <div ref={ref} className="gantt-tooltip" style={{ left, top }}>
       {/* ヘッダー */}
       <div className="gantt-tooltip-header">
         <span className="gantt-tooltip-name">{task.name}</span>

--- a/src/components/KanbanBoard.tsx
+++ b/src/components/KanbanBoard.tsx
@@ -157,7 +157,8 @@ export default function KanbanBoard({ tasks, onTasksChange }: Props) {
 
   // ── ドラッグ & ドロップ（列間移動 → 進捗更新）──
 
-  function handleDragStart(taskId: string) {
+  function handleDragStart(e: React.DragEvent, taskId: string) {
+    e.dataTransfer.setData('text/plain', taskId);
     setDraggingId(taskId);
   }
 
@@ -221,8 +222,8 @@ export default function KanbanBoard({ tasks, onTasksChange }: Props) {
             key={col.id}
             className={`kanban-column${isOver ? " kanban-column--dragover" : ""}`}
             onDragOver={(e) => { e.preventDefault(); setDragOverCol(col.id); }}
-            onDragLeave={() => setDragOverCol(null)}
-            onDrop={() => handleDrop(col)}
+            onDragLeave={(e) => { if (!e.currentTarget.contains(e.relatedTarget as Node)) setDragOverCol(null); }}
+            onDrop={(e) => { e.preventDefault(); handleDrop(col); }}
           >
             {/* 列ヘッダー */}
             <div className="kanban-col-header" style={{ borderTopColor: col.accentColor }}>
@@ -232,7 +233,7 @@ export default function KanbanBoard({ tasks, onTasksChange }: Props) {
             </div>
 
             {/* カード一覧 */}
-            <div className="kanban-cards">
+            <div className="kanban-cards" onDragOver={(e) => e.preventDefault()}>
               {colTasks.map((task) => {
                 const progress    = computeProgress(task.id, tasks);
                 const ancestors   = getAncestorNames(task.id, tasks);
@@ -243,7 +244,8 @@ export default function KanbanBoard({ tasks, onTasksChange }: Props) {
                     key={task.id}
                     className={`kanban-card${isDragging ? " kanban-card--dragging" : ""}`}
                     draggable
-                    onDragStart={() => handleDragStart(task.id)}
+                    onDragStart={(e) => handleDragStart(e, task.id)}
+                    onDragOver={(e) => e.preventDefault()}
                     onDragEnd={() => { setDraggingId(null); setDragOverCol(null); }}
                     onClick={() => openEdit(task)}
                     style={{ borderLeftColor: task.color ?? "#4A90D9" }}

--- a/src/styles.css
+++ b/src/styles.css
@@ -646,12 +646,10 @@
   z-index: 1;
   padding: 0 6px;
   font-size: 0.72rem;
-  color: #fff;
   font-weight: 600;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.4);
   pointer-events: none;
 }
 


### PR DESCRIPTION
## Summary

- **#40 ウィンドウ位置・サイズ永続化**: `tauri-plugin-window-state` を導入し、終了時のウィンドウ状態を次回起動時に復元
- **#41 カンバン D&D 修正**: `dataTransfer.setData()` 追加・子要素への `onDragOver` 追加・`tauri.conf.json` に `dragDropEnabled: false` を設定（Tauri のドロップインターセプトが根本原因）
- **#42 ガントバー文字色コントラスト**: WCAG 輝度計算で白/黒を動的選択。進捗オーバーレイ（`brightness(0.75)`）後の色で判定し、進捗が進んだ際の視認性も担保
- **ガントツールチップ下端見切れ修正**: `useLayoutEffect` で実際の高さを計測し、画面下端に近い場合はカーソル上方に反転表示

## Test plan

- [ ] カンバンでタスクカードを別カラムにドラッグ&ドロップできること
- [ ] ガントチャートで明るい色（薄い黄色・ライトグリーンなど）のバーに黒文字が表示されること
- [ ] 進捗100%のバーでも文字が読みやすいこと
- [ ] ガントツールチップが画面下部でも見切れないこと
- [ ] アプリ終了→再起動でウィンドウ位置・サイズが復元されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)