### PR TITLE
fix: 祝日取得のプロキシ環境での接続エラーを修正（native-tls対応）

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5391,7 +5391,7 @@ dependencies = [
 
 [[package]]
 name = "wbs"
-version = "1.0.12"
+version = "1.0.13"
 dependencies = [
  "backtrace",
  "chrono",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -26,7 +26,7 @@ tauri-plugin-process = "2"
 tauri-plugin-log = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
+reqwest = { version = "0.12", default-features = false, features = ["native-tls"] }
 encoding_rs = "0.8"
 backtrace = "0.3"
 chrono = "0.4"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -143,7 +143,8 @@ async fn fetch_holidays(app: tauri::AppHandle) -> Result<Vec<(String, String)>, 
 
 /// プロキシ URL を受け取って reqwest クライアントを構築する
 fn build_client(proxy_url: Option<String>) -> Result<reqwest::Client, String> {
-    let mut builder = reqwest::Client::builder();
+    let mut builder = reqwest::Client::builder()
+        .user_agent("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36");
     if let Some(url) = proxy_url {
         let proxy = reqwest::Proxy::all(&url)
             .map_err(|e| format!("プロキシ設定エラー: {e}"))?;


### PR DESCRIPTION
## Summary

- `reqwest` の TLS バックエンドを `rustls-tls` → `native-tls` に変更
- Windows のシステム証明書ストアを使うことで、社内プロキシ（SSL インスペクション）環境下でも `tauri-plugin-updater` と同様に通信できるように修正
- `build_client` に `User-Agent` を追加し、官公庁サーバーのボットフィルターを回避

## 原因

| | Updater（動作） | fetch_holidays（失敗） |
|---|---|---|
| TLS | native-tls（OS証明書ストア） | rustls-tls（Mozilla組み込みCAのみ） |
| 社内プロキシの独自CA | 信頼できる | 認識できず接続拒否 |

## Test plan

- [ ] プロキシ環境下で祝日取得が正常に動作することを確認
- [ ] プロキシなし環境でも祝日取得が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)