### PR TITLE
feat: ガントドラッグ改善・分析ビューに未割当タスク追加

### DIFF
--- a/src/components/AnalysisView.tsx
+++ b/src/components/AnalysisView.tsx
@@ -42,6 +42,12 @@ export default function AnalysisView({ tasks }: Props) {
     return Math.min(Math.round((todayTime - startTime) / totalDuration * 100), 100);
   }
 
+  // 未割当タスク: 担当者が設定されていない未完了の葉タスク
+  const unassignedTasks = useMemo(
+    () => leafTasks.filter((t) => !t.assignee && computeProgress(t.id, tasks) < 100),
+    [leafTasks, tasks]
+  );
+
   // 次のタスクがないメンバー
   const idleMembers = useMemo(() => {
     const assignees = [
@@ -162,6 +168,56 @@ export default function AnalysisView({ tasks }: Props) {
                             style={{ width: `${actual}%` }}
                           />
                           <span>{actual}% <span className="analysis-gap">(-{gap}%)</span></span>
+                        </div>
+                      </td>
+                      <td className="analysis-path">
+                        {ancestors.length > 0 ? ancestors.join(" > ") : "—"}
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </section>
+
+      {/* 未割当タスク */}
+      <section className="analysis-section">
+        <h2 className="analysis-section-title">
+          <span className="analysis-icon">👤</span>
+          未割当タスク
+          <span className="analysis-count">{unassignedTasks.length}件</span>
+        </h2>
+
+        {unassignedTasks.length === 0 ? (
+          <p className="analysis-empty">未割当のタスクはありません</p>
+        ) : (
+          <div className="analysis-table-wrapper">
+            <table className="analysis-table">
+              <thead>
+                <tr>
+                  <th>タスク名</th>
+                  <th>終了予定日</th>
+                  <th>進捗</th>
+                  <th>パス</th>
+                </tr>
+              </thead>
+              <tbody>
+                {unassignedTasks.map((t) => {
+                  const ancestors = getAncestorNames(t.id, tasks);
+                  const progress = computeProgress(t.id, tasks);
+                  return (
+                    <tr key={t.id}>
+                      <td className="analysis-task-name">{t.name}</td>
+                      <td>{formatDateYMD(t.endDate)}</td>
+                      <td>
+                        <div className="analysis-progress-bar">
+                          <div
+                            className="analysis-progress-fill"
+                            style={{ width: `${progress}%` }}
+                          />
+                          <span>{progress}%</span>
                         </div>
                       </td>
                       <td className="analysis-path">

--- a/src/components/GanttChart.tsx
+++ b/src/components/GanttChart.tsx
@@ -142,7 +142,7 @@ export default function GanttChart({ tasks, onTasksChange, holidays = new Map() 
 
   // ── 行並び替え ──
 
-  function reorderTasks(draggedId: string, targetId: string) {
+  function reorderTasks(draggedId: string, targetId: string, insertAfter = false) {
     const dragged = tasks.find((t) => t.id === draggedId);
     const target  = tasks.find((t) => t.id === targetId);
     if (!dragged || !target || dragged.parentId !== target.parentId) return;
@@ -153,7 +153,7 @@ export default function GanttChart({ tasks, onTasksChange, holidays = new Map() 
 
     const without   = siblings.filter((t) => t.id !== draggedId);
     const targetIdx = without.findIndex((t) => t.id === targetId);
-    without.splice(targetIdx, 0, dragged);
+    without.splice(insertAfter ? targetIdx + 1 : targetIdx, 0, dragged);
 
     const updatedOrders = new Map(without.map((t, i) => [t.id, i]));
     const updated = tasks.map((t) =>

--- a/src/components/GanttLeftPanel.tsx
+++ b/src/components/GanttLeftPanel.tsx
@@ -62,7 +62,7 @@ interface Props {
   onFilterParentChange: (value: string) => void;
   onFilterAssigneeChange: (value: string) => void;
   onLeftScroll: () => void;
-  onReorderTasks: (draggedId: string, targetId: string) => void;
+  onReorderTasks: (draggedId: string, targetId: string, insertAfter?: boolean) => void;
 }
 
 export default function GanttLeftPanel({
@@ -87,11 +87,17 @@ export default function GanttLeftPanel({
   onReorderTasks,
 }: Props) {
   const draggedIdRef = useRef<string | null>(null);
-  const [dragOverId, setDragOverId] = useState<string | null>(null);
+  const [dragOverId,      setDragOverId]      = useState<string | null>(null);
+  const [dragInsertAfter, setDragInsertAfter] = useState(false);
 
   function handleDragStart(e: React.DragEvent, taskId: string) {
     draggedIdRef.current = taskId;
     e.dataTransfer.effectAllowed = "move";
+  }
+
+  function getInsertAfter(e: React.DragEvent): boolean {
+    const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
+    return e.clientY > rect.top + rect.height / 2;
   }
 
   function handleDragOver(e: React.DragEvent, taskId: string) {
@@ -103,6 +109,7 @@ export default function GanttLeftPanel({
     if (!dragged || !target || dragged.parentId !== target.parentId) return;
     e.dataTransfer.dropEffect = "move";
     setDragOverId(taskId);
+    setDragInsertAfter(getInsertAfter(e));
   }
 
   function handleDrop(e: React.DragEvent, targetId: string) {
@@ -115,7 +122,7 @@ export default function GanttLeftPanel({
     const dragged = tasks.find((t) => t.id === draggedId);
     const target  = tasks.find((t) => t.id === targetId);
     if (dragged && target && dragged.parentId === target.parentId && !!dragged.isFloating === !!target.isFloating) {
-      onReorderTasks(draggedId, targetId);
+      onReorderTasks(draggedId, targetId, getInsertAfter(e));
     }
     draggedIdRef.current = null;
     setDragOverId(null);
@@ -191,7 +198,7 @@ export default function GanttLeftPanel({
           return (
             <div
               key={task.id}
-              className={`gantt-row gantt-row-depth-${Math.min(depth, 3)}${effectiveProg === 100 ? " gantt-row--done" : ""}${isDragOver ? " gantt-row--drag-over" : ""}`}
+              className={`gantt-row gantt-row-depth-${Math.min(depth, 3)}${effectiveProg === 100 ? " gantt-row--done" : ""}${isDragOver && !dragInsertAfter ? " gantt-row--drag-over-top" : ""}${isDragOver && dragInsertAfter ? " gantt-row--drag-over-bottom" : ""}`}
               style={{ height: ROW_HEIGHT }}
               draggable
               onDragStart={(e) => handleDragStart(e, task.id)}
@@ -279,7 +286,7 @@ export default function GanttLeftPanel({
             return (
               <div
                 key={task.id}
-                className={`gantt-row gantt-row-depth-0 gantt-row--floating${effectiveProg === 100 ? " gantt-row--done" : ""}${isDragOver ? " gantt-row--drag-over" : ""}`}
+                className={`gantt-row gantt-row-depth-0 gantt-row--floating${effectiveProg === 100 ? " gantt-row--done" : ""}${isDragOver && !dragInsertAfter ? " gantt-row--drag-over-top" : ""}${isDragOver && dragInsertAfter ? " gantt-row--drag-over-bottom" : ""}`}
                 style={{ height: ROW_HEIGHT }}
                 draggable
                 onDragStart={(e) => handleDragStart(e, task.id)}

--- a/src/styles.css
+++ b/src/styles.css
@@ -273,6 +273,7 @@
 }
 
 .gantt-row {
+  position: relative;
   display: flex;
   align-items: center;
   border-bottom: 1px solid #eef1f6;
@@ -306,23 +307,30 @@
   background: #eef3ff;
 }
 
-.gantt-row--drag-over {
+.gantt-row--drag-over-top {
   border-top: 2px solid #4a90d9;
+  background: #ddeeff;
+}
+.gantt-row--drag-over-bottom {
+  border-bottom: 2px solid #4a90d9;
   background: #ddeeff;
 }
 
 .gantt-drag-handle {
   display: none;
+  position: absolute;
+  left: 2px;
+  top: 50%;
+  transform: translateY(-50%);
   padding: 0 4px;
   color: #aaa;
   cursor: grab;
   font-size: 1rem;
   line-height: 1;
-  flex-shrink: 0;
 }
 
 .gantt-row:hover .gantt-drag-handle {
-  display: inline;
+  display: block;
 }
 
 .gantt-drag-handle:active {


### PR DESCRIPTION
## Summary

- ガントチャートのドラッグ＆ドロップで、カーソルの上下位置（行の上半分/下半分）により挿入位置を判定するよう変更。最下部への移動が可能になった
- ドラッグハンドル（⠿）を `position: absolute` にして、ホバー時にタスク名がずれる問題を修正
- 分析ビューに「未割当タスク」セクションを追加（担当者未設定・未完了の葉タスクを一覧表示）

## Test plan

- [ ] ガントチャートでタスクをドラッグし、最下部（最後のタスクの下半分）にドロップして最下位に移動できることを確認
- [ ] ドラッグハンドルホバー時にタスク名のインデントがずれないことを確認
- [ ] 分析ビューに担当者未設定の未完了タスクが表示されることを確認
- [ ] 担当者未設定タスクが0件のとき「未割当のタスクはありません」と表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)