### PR TITLE
fix: 折り畳みボタンとドラッグハンドルの重なりを解消 (close #61)

### DIFF
--- a/src/components/GanttLeftPanel.tsx
+++ b/src/components/GanttLeftPanel.tsx
@@ -228,10 +228,15 @@ export default function GanttLeftPanel({
               </span>
               <span
                 className="gantt-col-task"
-                style={{ paddingLeft: depth * INDENT_PER_LEVEL + 8 }}
+                style={{ paddingLeft: depth * INDENT_PER_LEVEL + 22 }}
               >
                 {hasChildren ? (
-                  <button className="gantt-collapse-btn" onClick={() => onToggleCollapse(task.id)}>
+                  <button
+                    className="gantt-collapse-btn"
+                    onClick={() => onToggleCollapse(task.id)}
+                    draggable={false}
+                    onDragStart={(e) => e.stopPropagation()}
+                  >
                     {isCollapsed ? "▶" : "▼"}
                   </button>
                 ) : (


### PR DESCRIPTION
## Summary

- `gantt-col-task` の `paddingLeft` 基準値を `8px → 22px` に変更し、折り畳みボタン（▶/▼）がドラッグハンドル（⠿, `left: 2px`）と視覚的に重ならないようにした（案3）
- 折り畳みボタンに `draggable={false}` と `onDragStart` の `stopPropagation` を追加し、クリック時にドラッグが誤発動しないようにした（案1）

## Test plan

- [ ] 子タスクを持つ depth=0 のタスクで折り畳みボタン（▶/▼）をクリックできること
- [ ] クリック中に少しマウスが動いても折り畳みが正常に動作すること（ドラッグが誤発動しないこと）
- [ ] ホバー時にドラッグハンドル（⠿）が折り畳みボタンと重ならずに表示されること
- [ ] 各 depth（0〜3）でインデントが正しく表示されること

Closes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)