### PR TITLE
feat: カンバンの追加モーダルから単発タスクを直接登録できるようにする

### DIFF
--- a/src/components/KanbanBoard.tsx
+++ b/src/components/KanbanBoard.tsx
@@ -76,6 +76,7 @@ interface AddState {
   color: string;
   parentId?: string;
   copySourceId?: string;
+  isFloating?: boolean;
 }
 
 // ── コンポーネント ────────────────────────────────────────
@@ -156,9 +157,19 @@ export default function KanbanBoard({ tasks, onTasksChange }: Props) {
 
   function confirmAdd() {
     if (!addState || !addState.name.trim()) return;
-    const newStart = new Date(addState.startDate);
-    const newEnd = new Date(addState.endDate);
-    if (isNaN(newStart.getTime()) || isNaN(newEnd.getTime()) || newStart > newEnd) return;
+
+    const today = new Date();
+    let newStart: Date;
+    let newEnd: Date;
+
+    if (addState.isFloating) {
+      newStart = today;
+      newEnd = today;
+    } else {
+      newStart = new Date(addState.startDate);
+      newEnd = new Date(addState.endDate);
+      if (isNaN(newStart.getTime()) || isNaN(newEnd.getTime()) || newStart > newEnd) return;
+    }
 
     const col = COLUMNS.find((c) => c.id === addState.columnId)!;
     const initProg = col.dropProgress(0);
@@ -177,6 +188,7 @@ export default function KanbanBoard({ tasks, onTasksChange }: Props) {
       endDate: newEnd,
       progress: initProg,
       color: addState.color,
+      ...(addState.isFloating ? { isFloating: true } : {}),
       ...(addState.parentId ? { parentId: addState.parentId } : {}),
       ...(copiedFields
         ? {
@@ -189,6 +201,9 @@ export default function KanbanBoard({ tasks, onTasksChange }: Props) {
     };
     onTasksChange([...tasks, newTask]);
     setAddState(null);
+    if (addState.isFloating) {
+      setFilterParentId("__floating__");
+    }
   }
 
   // ── ドラッグ & ドロップ（列間移動 → 進捗更新）──
@@ -490,28 +505,41 @@ export default function KanbanBoard({ tasks, onTasksChange }: Props) {
               }}
             />
 
-            <div className="modal-date-row">
-              <div className="modal-date-field">
-                <label className="modal-label">開始日</label>
-                <input
-                  type="date"
-                  value={addState.startDate}
-                  max={addState.endDate}
-                  onChange={(e) => setAddState({ ...addState, startDate: e.target.value })}
-                  className="date-input"
-                />
+            {/* 単発タスク（日付未定）チェックボックス */}
+            <label className="modal-floating-label">
+              <input
+                type="checkbox"
+                checked={addState.isFloating ?? false}
+                onChange={(e) => setAddState({ ...addState, isFloating: e.target.checked })}
+                className="modal-floating-checkbox"
+              />
+              単発タスク（開始時期未定）
+            </label>
+
+            {!addState.isFloating && (
+              <div className="modal-date-row">
+                <div className="modal-date-field">
+                  <label className="modal-label">開始日</label>
+                  <input
+                    type="date"
+                    value={addState.startDate}
+                    max={addState.endDate}
+                    onChange={(e) => setAddState({ ...addState, startDate: e.target.value })}
+                    className="date-input"
+                  />
+                </div>
+                <div className="modal-date-field">
+                  <label className="modal-label">終了日</label>
+                  <input
+                    type="date"
+                    value={addState.endDate}
+                    min={addState.startDate}
+                    onChange={(e) => setAddState({ ...addState, endDate: e.target.value })}
+                    className="date-input"
+                  />
+                </div>
               </div>
-              <div className="modal-date-field">
-                <label className="modal-label">終了日</label>
-                <input
-                  type="date"
-                  value={addState.endDate}
-                  min={addState.startDate}
-                  onChange={(e) => setAddState({ ...addState, endDate: e.target.value })}
-                  className="date-input"
-                />
-              </div>
-            </div>
+            )}
 
             <div className="modal-color-row">
               <label className="modal-label">カラー</label>


### PR DESCRIPTION
## Summary

- カンバンの追加モーダルに「単発タスク（開始時期未定）」チェックボックスを追加
- チェックON時は開始日・終了日フィールドを非表示にし、日付バリデーションをスキップ
- 単発タスク追加後、フィルタを「未スケジュール（`__floating__`）」に自動切替

Closes #63

## Test plan

- [ ] カンバンの追加モーダルで「単発タスク（開始時期未定）」チェックをONにすると日付フィールドが非表示になる
- [ ] チェックONのまま追加すると `isFloating: true` のタスクが作成される
- [ ] 追加後にフィルタが「未スケジュール」に切り替わり、作成したタスクが表示される
- [ ] チェックOFFの場合は従来通り日付入力・バリデーションが機能する

🤖 Generated with [Claude Code](https://claude.com/claude-code)