### PR TITLE
feat: 分析ビューにタスク重複メンバーセクションを追加

### DIFF
--- a/src/components/AnalysisView.tsx
+++ b/src/components/AnalysisView.tsx
@@ -51,6 +51,41 @@ export default function AnalysisView({ tasks }: Props) {
     [leafTasks, tasks],
   );
 
+  // タスク重複メンバー: 同時期に複数タスクを抱えているメンバー
+  const overlappingMembers = useMemo(() => {
+    const activeTasks = leafTasks.filter((t) => computeProgress(t.id, tasks) < 100);
+    const memberTaskMap = new Map<string, Task[]>();
+    for (const t of activeTasks) {
+      const members: string[] = [];
+      if (t.assignee) members.push(t.assignee);
+      if (t.subMembers) members.push(...t.subMembers);
+      for (const m of members) {
+        if (!memberTaskMap.has(m)) memberTaskMap.set(m, []);
+        memberTaskMap.get(m)!.push(t);
+      }
+    }
+    const result: {
+      member: string;
+      pairs: { taskA: Task; taskB: Task; overlapStart: Date; overlapEnd: Date }[];
+    }[] = [];
+    for (const [member, mTasks] of memberTaskMap) {
+      const pairs: { taskA: Task; taskB: Task; overlapStart: Date; overlapEnd: Date }[] = [];
+      for (let i = 0; i < mTasks.length; i++) {
+        for (let j = i + 1; j < mTasks.length; j++) {
+          const a = mTasks[i];
+          const b = mTasks[j];
+          if (a.startDate <= b.endDate && a.endDate >= b.startDate) {
+            const overlapStart = a.startDate > b.startDate ? a.startDate : b.startDate;
+            const overlapEnd = a.endDate < b.endDate ? a.endDate : b.endDate;
+            pairs.push({ taskA: a, taskB: b, overlapStart, overlapEnd });
+          }
+        }
+      }
+      if (pairs.length > 0) result.push({ member, pairs });
+    }
+    return result;
+  }, [leafTasks, tasks]);
+
   // 次のタスクがないメンバー
   const idleMembers = useMemo(() => {
     const assignees = [...new Set(leafTasks.map((t) => t.assignee).filter(Boolean) as string[])];
@@ -228,6 +263,59 @@ export default function AnalysisView({ tasks }: Props) {
                 })}
               </tbody>
             </table>
+          </div>
+        )}
+      </section>
+
+      {/* タスク重複メンバー */}
+      <section className="analysis-section">
+        <h2 className="analysis-section-title">
+          <span className="analysis-icon">🔀</span>
+          タスク重複メンバー
+          <span className="analysis-count">{overlappingMembers.length}人</span>
+        </h2>
+
+        {overlappingMembers.length === 0 ? (
+          <p className="analysis-empty">タスクが重複しているメンバーはいません</p>
+        ) : (
+          <div className="analysis-overlap-list">
+            {overlappingMembers.map(({ member, pairs }) => (
+              <div key={member} className="analysis-overlap-member">
+                <div className="analysis-overlap-member-name">{member}</div>
+                <div className="analysis-table-wrapper">
+                  <table className="analysis-table">
+                    <thead>
+                      <tr>
+                        <th>タスクA</th>
+                        <th>タスクB</th>
+                        <th>重複期間</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {pairs.map(({ taskA, taskB, overlapStart, overlapEnd }, idx) => (
+                        <tr key={idx}>
+                          <td className="analysis-task-name">
+                            {taskA.name}
+                            <span className="analysis-date-range">
+                              {formatDateYMD(taskA.startDate)}〜{formatDateYMD(taskA.endDate)}
+                            </span>
+                          </td>
+                          <td className="analysis-task-name">
+                            {taskB.name}
+                            <span className="analysis-date-range">
+                              {formatDateYMD(taskB.startDate)}〜{formatDateYMD(taskB.endDate)}
+                            </span>
+                          </td>
+                          <td className="analysis-overlap-range">
+                            {formatDateYMD(overlapStart)}〜{formatDateYMD(overlapEnd)}
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              </div>
+            ))}
           </div>
         )}
       </section>

--- a/src/styles.css
+++ b/src/styles.css
@@ -2096,6 +2096,41 @@
   white-space: nowrap;
 }
 
+.analysis-overlap-list {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.analysis-overlap-member {
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.analysis-overlap-member-name {
+  background: #f1f5f9;
+  color: #334155;
+  font-weight: 700;
+  font-size: 0.9rem;
+  padding: 8px 14px;
+  border-bottom: 1px solid #e2e8f0;
+}
+
+.analysis-date-range {
+  display: block;
+  font-size: 0.78rem;
+  color: #64748b;
+  margin-top: 2px;
+}
+
+.analysis-overlap-range {
+  white-space: nowrap;
+  color: #dc2626;
+  font-weight: 600;
+  font-size: 0.85rem;
+}
+
 .analysis-idle-members {
   display: flex;
   flex-wrap: wrap;


### PR DESCRIPTION
## Summary

- 分析ビューに「タスク重複メンバー」セクションを追加 (closes #64)
- 未完了の葉タスクを対象に `assignee` と `subMembers` 両方からメンバーを集約し、期間が重なるタスクペアを全組み合わせで検出
- メンバーごとにグルーピングし、重複タスクA・B・重複期間を表形式で表示

## Test plan

- [ ] 同一メンバーに期間が重なる2つ以上のタスクを設定し、セクションに表示されることを確認
- [ ] 完了済みタスク（progress=100）が検出対象から除外されることを確認
- [ ] `subMembers` に設定されたメンバーも検出されることを確認
- [ ] 重複なしの場合「タスクが重複しているメンバーはいません」と表示されることを確認
- [ ] 3タスク重複時に全ペア（A-B, A-C, B-C）が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)