### PR TITLE
fix: メモ内のMarkdownリンクをTauri WebViewではなく標準ブラウザで開く

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-dialog": "^2.6.0",
         "@tauri-apps/plugin-log": "^2.8.0",
+        "@tauri-apps/plugin-opener": "^2.5.3",
         "@tauri-apps/plugin-process": "^2",
         "@tauri-apps/plugin-updater": "^2",
         "exceljs": "^4.4.0",
@@ -2208,6 +2209,15 @@
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-log/-/plugin-log-2.8.0.tgz",
       "integrity": "sha512-a+7rOq3MJwpTOLLKbL8d0qGZ85hgHw5pNOWusA9o3cf7cEgtYHiGY/+O8fj8MvywQIGqFv0da2bYQDlrqLE7rw==",
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@tauri-apps/api": "^2.8.0"
+      }
+    },
+    "node_modules/@tauri-apps/plugin-opener": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-opener/-/plugin-opener-2.5.3.tgz",
+      "integrity": "sha512-CCcUltXMOfUEArbf3db3kCE7Ggy1ExBEBl51Ko2ODJ6GDYHRp1nSNlQm5uNCFY5k7/ufaK5Ib3Du/Zir19IYQQ==",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "@tauri-apps/api": "^2.8.0"

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@tauri-apps/api": "^2",
     "@tauri-apps/plugin-dialog": "^2.6.0",
     "@tauri-apps/plugin-log": "^2.8.0",
+    "@tauri-apps/plugin-opener": "^2.5.3",
     "@tauri-apps/plugin-process": "^2",
     "@tauri-apps/plugin-updater": "^2",
     "exceljs": "^4.4.0",

--- a/src/components/GanttTooltip.tsx
+++ b/src/components/GanttTooltip.tsx
@@ -4,6 +4,7 @@
 import { useRef, useLayoutEffect, useState } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
+import { markdownComponents } from "./MarkdownComponents";
 import { Task } from "../types/task";
 
 interface Props {
@@ -50,7 +51,9 @@ export default function GanttTooltip({ task, progress, x, y }: Props) {
         <>
           <div className="gantt-tooltip-divider" />
           <div className="gantt-tooltip-memo markdown-body">
-            <ReactMarkdown remarkPlugins={[remarkGfm]}>{task.memo}</ReactMarkdown>
+            <ReactMarkdown remarkPlugins={[remarkGfm]} components={markdownComponents}>
+              {task.memo}
+            </ReactMarkdown>
           </div>
         </>
       )}

--- a/src/components/MarkdownComponents.tsx
+++ b/src/components/MarkdownComponents.tsx
@@ -1,0 +1,26 @@
+/**
+ * ReactMarkdown の components プロップに渡す共通コンポーネント
+ * リンクをクリックすると Tauri の opener で標準ブラウザを開く
+ */
+import { openUrl } from "@tauri-apps/plugin-opener";
+
+export const markdownComponents = {
+  a: ({
+    href,
+    children,
+    ...props
+  }: React.AnchorHTMLAttributes<HTMLAnchorElement> & {
+    children?: React.ReactNode;
+  }) => (
+    <a
+      {...props}
+      href={href}
+      onClick={(e) => {
+        e.preventDefault();
+        if (href) openUrl(href);
+      }}
+    >
+      {children}
+    </a>
+  ),
+};

--- a/src/components/MemoField.tsx
+++ b/src/components/MemoField.tsx
@@ -6,6 +6,7 @@ import { useState } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import TurndownService from "turndown";
+import { markdownComponents } from "./MarkdownComponents";
 
 interface Props {
   value: string;
@@ -54,7 +55,9 @@ export default function MemoField({ value, onChange }: Props) {
       {preview ? (
         <div className="memo-preview markdown-body">
           {value.trim() ? (
-            <ReactMarkdown remarkPlugins={[remarkGfm]}>{value}</ReactMarkdown>
+            <ReactMarkdown remarkPlugins={[remarkGfm]} components={markdownComponents}>
+              {value}
+            </ReactMarkdown>
           ) : (
             <span className="memo-preview-empty">メモなし</span>
           )}

--- a/src/components/MemoView.tsx
+++ b/src/components/MemoView.tsx
@@ -3,6 +3,7 @@
  */
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
+import { markdownComponents } from "./MarkdownComponents";
 
 interface Props {
   children: string;
@@ -13,7 +14,9 @@ interface Props {
 export default function MemoView({ children, compact = false }: Props) {
   return (
     <div className={`markdown-body${compact ? " markdown-body--compact" : ""}`}>
-      <ReactMarkdown remarkPlugins={[remarkGfm]}>{children}</ReactMarkdown>
+      <ReactMarkdown remarkPlugins={[remarkGfm]} components={markdownComponents}>
+        {children}
+      </ReactMarkdown>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- `@tauri-apps/plugin-opener` をフロントエンド依存に追加
- `src/components/MarkdownComponents.tsx` を新規作成し、リンククリック時に `e.preventDefault()` + `openUrl()` で標準ブラウザを開く共通コンポーネントを定義
- `MemoField.tsx`、`MemoView.tsx`、`GanttTooltip.tsx` の `ReactMarkdown` に `components={markdownComponents}` を適用

## Test plan

- [ ] タスクのメモに `[link](https://example.com)` を入力
- [ ] プレビュータブでリンクをクリック → WebView 内でナビゲートされず、標準ブラウザで開くことを確認
- [ ] カンバンカードのメモ表示でリンクをクリック → 同様に確認
- [ ] ガントバーのホバーツールチップでリンクをクリック → 同様に確認

Closes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)