### PR TITLE
feat: メモ貼り付け時にHTMLをMarkdownへ変換する

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wbs",
-  "version": "1.0.14",
+  "version": "1.0.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wbs",
-      "version": "1.0.14",
+      "version": "1.0.15",
       "dependencies": {
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-dialog": "^2.6.0",
@@ -17,7 +17,8 @@
         "react": "^18",
         "react-dom": "^18",
         "react-markdown": "^10.1.0",
-        "remark-gfm": "^4.0.1"
+        "remark-gfm": "^4.0.1",
+        "turndown": "^7.2.2"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
@@ -28,6 +29,7 @@
         "@testing-library/user-event": "^14.6.1",
         "@types/react": "^18",
         "@types/react-dom": "^18",
+        "@types/turndown": "^5.0.6",
         "@typescript-eslint/eslint-plugin": "^8.57.1",
         "@typescript-eslint/parser": "^8.57.1",
         "@vitejs/plugin-react": "^4",
@@ -1304,6 +1306,12 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@mixmark-io/domino": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@mixmark-io/domino/-/domino-2.2.0.tgz",
+      "integrity": "sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw==",
+      "license": "BSD-2-Clause"
+    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.1.tgz",
@@ -2482,6 +2490,13 @@
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
+    },
+    "node_modules/@types/turndown": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@types/turndown/-/turndown-5.0.6.tgz",
+      "integrity": "sha512-ru00MoyeeouE5BX4gRL+6m/BsDfbRayOskWqUvh7CLGW+UXxHQItqALa38kKnOiZPqJrtzJUgAC2+F0rL1S4Pg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/unist": {
       "version": "3.0.3",
@@ -7111,6 +7126,15 @@
       "dev": true,
       "license": "0BSD",
       "optional": true
+    },
+    "node_modules/turndown": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/turndown/-/turndown-7.2.2.tgz",
+      "integrity": "sha512-1F7db8BiExOKxjSMU2b7if62D/XOyQyZbPKq/nUwopfgnHlqXHqQ0lvfUTeUIr1lZJzOPFn43dODyMSIfvWRKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@mixmark-io/domino": "^2.2.0"
+      }
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "react": "^18",
     "react-dom": "^18",
     "react-markdown": "^10.1.0",
-    "remark-gfm": "^4.0.1"
+    "remark-gfm": "^4.0.1",
+    "turndown": "^7.2.2"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
@@ -37,6 +38,7 @@
     "@testing-library/user-event": "^14.6.1",
     "@types/react": "^18",
     "@types/react-dom": "^18",
+    "@types/turndown": "^5.0.6",
     "@typescript-eslint/eslint-plugin": "^8.57.1",
     "@typescript-eslint/parser": "^8.57.1",
     "@vitejs/plugin-react": "^4",

--- a/src/components/MemoField.tsx
+++ b/src/components/MemoField.tsx
@@ -5,14 +5,29 @@
 import { useState } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
+import TurndownService from "turndown";
 
 interface Props {
   value: string;
   onChange: (v: string) => void;
 }
 
+const turndownService = new TurndownService({ headingStyle: "atx", codeBlockStyle: "fenced" });
+
 export default function MemoField({ value, onChange }: Props) {
   const [preview, setPreview] = useState(false);
+
+  const handlePaste = (e: React.ClipboardEvent<HTMLTextAreaElement>) => {
+    const html = e.clipboardData.getData("text/html");
+    if (!html) return;
+    e.preventDefault();
+    const markdown = turndownService.turndown(html);
+    const textarea = e.currentTarget;
+    const start = textarea.selectionStart;
+    const end = textarea.selectionEnd;
+    const newValue = value.slice(0, start) + markdown + value.slice(end);
+    onChange(newValue);
+  };
 
   return (
     <div className="memo-field">
@@ -48,6 +63,7 @@ export default function MemoField({ value, onChange }: Props) {
         <textarea
           value={value}
           onChange={(e) => onChange(e.target.value)}
+          onPaste={handlePaste}
           placeholder={"Markdown 形式で入力できます\n例: **太字** `コード` - リスト"}
           className="memo-input"
           rows={5}


### PR DESCRIPTION
## Summary

- `turndown` ライブラリを追加し、HTMLをMarkdownへ変換する機能を実装
- `MemoField.tsx` の `<textarea>` に `onPaste` ハンドラを追加
- Word・Excel・Webページ等からコピーしたリッチテキストを貼り付けた際、HTMLをMarkdownに変換してカーソル位置に挿入
- プレーンテキストのみの場合はデフォルトの貼り付け動作をそのまま通す

Closes #68

## Test plan

- [ ] Webページからテキストをコピーしてメモ欄に貼り付け、Markdownに変換されることを確認
- [ ] 太字・リスト・見出しなどのHTMLが対応するMarkdown記法に変換されることを確認
- [ ] プレーンテキストの貼り付けが従来通り動作することを確認
- [ ] プレビュータブで変換されたMarkdownが正しくレンダリングされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)