### PR TITLE
fix: ガント以外のビューに flex: 1 を追加してウィンドウ横幅を活用できるよう修正

### DIFF
--- a/src/components/MemoField.tsx
+++ b/src/components/MemoField.tsx
@@ -67,9 +67,7 @@ export default function MemoField({ value, onChange }: Props) {
           value={value}
           onChange={(e) => onChange(e.target.value)}
           onPaste={handlePaste}
-          placeholder={
-            "Markdown 形式で入力できます\n例: **太字** `コード` - リスト"
-          }
+          placeholder={"Markdown 形式で入力できます\n例: **太字** `コード` - リスト"}
           className="memo-input"
           rows={5}
         />


### PR DESCRIPTION
## Summary

- `.kanban-wrapper` に `flex: 1; min-width: 0;` を追加し、`height: calc(100vh - 80px)` を `height: 100%` に修正
- `.analysis-view` に `flex: 1; min-width: 0;` を追加
- `.archive-view` に `flex: 1; min-width: 0;` を追加

Closes #73

## Test plan

- [ ] カンバンビューがウィンドウ横幅いっぱいに表示されること
- [ ] 分析ビューがウィンドウ横幅いっぱいに表示されること
- [ ] アーカイブビューがウィンドウ横幅いっぱいに表示されること
- [ ] ガント・検索ビューのレイアウトが崩れていないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)