### PR TITLE
feat: ガントチャートの開閉状態を永続化

### DIFF
--- a/src/components/GanttChart.tsx
+++ b/src/components/GanttChart.tsx
@@ -56,7 +56,9 @@ export default function GanttChart({ tasks, onTasksChange, holidays = new Map() 
   const timelineRef = useRef<HTMLDivElement>(null);
   const leftScrollRef = useRef<HTMLDivElement>(null);
 
-  const [collapsedIds, setCollapsedIds] = useState<Set<string>>(new Set());
+  const [collapsedIds, setCollapsedIds] = useState<Set<string>>(
+    () => new Set(tasks.filter((t) => t.collapsed).map((t) => t.id)),
+  );
   const [editingId, setEditingId] = useState<string | null>(null);
   const [memoPanelId, setMemoPanelId] = useState<string | null>(null);
   const [editingNameId, setEditingNameId] = useState<string | null>(null);
@@ -92,12 +94,14 @@ export default function GanttChart({ tasks, onTasksChange, holidays = new Map() 
   // ── 操作 ──
 
   function toggleCollapse(id: string) {
+    const willBeCollapsed = !collapsedIds.has(id);
     setCollapsedIds((prev) => {
       const next = new Set(prev);
-      if (next.has(id)) next.delete(id);
-      else next.add(id);
+      if (willBeCollapsed) next.add(id);
+      else next.delete(id);
       return next;
     });
+    onTasksChange(tasks.map((t) => (t.id === id ? { ...t, collapsed: willBeCollapsed } : t)));
   }
 
   function commitRename(taskId: string, newName: string) {

--- a/src/utils/taskStorage.ts
+++ b/src/utils/taskStorage.ts
@@ -13,6 +13,7 @@ interface TaskRaw {
   progress: number;
   color?: string;
   parentId?: string;
+  collapsed?: boolean;
   assignee?: string;
   subMembers?: string[];
   progressCount?: { done: number; total: number };


### PR DESCRIPTION
## Summary

- `TaskRaw` に `collapsed?: boolean` を追加し、JSON保存・復元に対応
- `collapsedIds` の初期値をタスクの `collapsed` フラグから生成することで、リロード後も開閉状態を復元
- `toggleCollapse` 実行時に `onTasksChange` でタスクデータの `collapsed` プロパティを更新し、Tauri バックエンド経由で永続化

## Test plan

- [ ] タスクを折りたたんだ状態でアプリを再起動し、折りたたみ状態が復元されることを確認
- [ ] タスクを展開した状態でアプリを再起動し、展開状態が復元されることを確認
- [ ] 親タスクフィルタ変更時に折りたたみ状態がリセットされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)