### PR TITLE
fix: ダークモードでリマインダー繰り返し選択が真っ白になる問題を修正

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -3705,6 +3705,14 @@
 }
 
 /* ── Reminder ── */
+[data-theme="dark"] .reminder-repeat-select {
+  background: #252730;
+  border-color: #353845;
+  color: #c9d1d9;
+}
+[data-theme="dark"] .reminder-repeat-select:focus {
+  border-color: #4a9eff;
+}
 [data-theme="dark"] .btn-clear-reminder {
   border-color: #353845;
   color: #6e7080;


### PR DESCRIPTION
## Summary
- ダークモード時に `.reminder-repeat-select`（繰り返し選択）のスタイルが未定義で、`background: #fff` のまま文字色も白になり何も見えない状態だった
- `[data-theme="dark"]` 用のスタイルを追加し、背景・ボーダー・テキスト色を他のダークモード要素と統一

## Test plan
- [ ] ダークモードでタスクのリマインダー設定を開き、「繰り返し」セレクトボックスが正常に表示されることを確認
- [ ] ライトモードでも表示が崩れていないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)