### PR TITLE
fix: ノートビューのツリーから進捗ステータスバッジを削除

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5501,7 +5501,7 @@ dependencies = [
 
 [[package]]
 name = "wbs"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "backtrace",
  "chrono",

--- a/src/components/NoteView.tsx
+++ b/src/components/NoteView.tsx
@@ -8,7 +8,7 @@ import remarkGfm from "remark-gfm";
 import TurndownService from "turndown";
 import { markdownComponents } from "./MarkdownComponents";
 import { Task } from "../types/task";
-import { computeProgress, getSignalStatus, getDepth, isVisible } from "../utils/taskUtils";
+import { computeProgress, getDepth, isVisible } from "../utils/taskUtils";
 import { INDENT_PER_LEVEL } from "../constants/layout";
 
 const turndownService = new TurndownService({ headingStyle: "atx", codeBlockStyle: "fenced" });
@@ -134,7 +134,6 @@ export default function NoteView({ tasks, onTasksChange }: Props) {
             const isCollapsed = collapsedIds.has(task.id);
             const isSelected = task.id === selectedId;
             const hasMemo = !!(task.memo && task.memo.trim());
-            const signal = getSignalStatus(task.id, activeTasks);
 
             return (
               <div
@@ -157,7 +156,6 @@ export default function NoteView({ tasks, onTasksChange }: Props) {
                 ) : (
                   <span className="note-tree-leaf-icon">─</span>
                 )}
-                {signal !== "none" && <span className={`status-signal status-signal--${signal}`} />}
                 <span className="note-tree-item-name">{task.name}</span>
                 {hasMemo && <span className="note-tree-memo-dot" title="メモあり" />}
               </div>


### PR DESCRIPTION
## Summary
- ノートビューの左ツリーパネルに表示されていた進捗ステータスバッジ（`status-signal` 色ドット）を削除
- 合わせて不要になった `getSignalStatus` のインポートと変数参照もクリーンアップ

## Test plan
- [ ] ノートビューのタスクツリーにステータスバッジ（色ドット）が表示されないことを確認
- [ ] ガントチャート・カンバン等の他ビューでステータスバッジが引き続き表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)