### PR TITLE
fix: メモへのHTMLペースト時に改行を再現する

### DIFF
--- a/src/components/MemoField.tsx
+++ b/src/components/MemoField.tsx
@@ -12,6 +12,10 @@ interface Props {
 }
 
 const turndownService = new TurndownService({ headingStyle: "atx", codeBlockStyle: "fenced" });
+turndownService.addRule("lineBreak", {
+  filter: "br",
+  replacement: () => "  \n",
+});
 
 export default function MemoField({ value, onChange }: Props) {
   const handlePaste = (e: React.ClipboardEvent<HTMLTextAreaElement>) => {

--- a/src/components/NoteView.tsx
+++ b/src/components/NoteView.tsx
@@ -12,6 +12,10 @@ import { computeProgress, getDepth, isVisible } from "../utils/taskUtils";
 import { INDENT_PER_LEVEL } from "../constants/layout";
 
 const turndownService = new TurndownService({ headingStyle: "atx", codeBlockStyle: "fenced" });
+turndownService.addRule("lineBreak", {
+  filter: "br",
+  replacement: () => "  \n",
+});
 
 function getAncestors(taskId: string, tasks: Task[]): Task[] {
   const task = tasks.find((t) => t.id === taskId);


### PR DESCRIPTION
## Summary

- `MemoField.tsx` と `NoteView.tsx` の TurndownService に `<br>` カスタムルールを追加
- `<br>` タグを Markdown のハード改行（行末スペース2つ + 改行 `  \n`）に変換するよう修正
- これにより、Web ページやリッチテキストからHTMLをペーストした際に、元の改行がプレビューでも再現される

## 背景

従来の実装では `<br>` がただの `\n`（単純改行）に変換されていたため、Markdown レンダリング時に段落内の改行が無視され、1行に結合されてしまっていた。

## Test plan

- [ ] Web ページのテキストをコピーしてメモ欄にペーストし、改行が再現されることを確認
- [ ] `<br>` を含む HTML をペーストしてプレビューで改行が表示されることを確認
- [ ] NoteView のメモ欄でも同様に動作することを確認
- [ ] 改行を含まない通常のテキストペーストが壊れていないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)