### PR TITLE
feat: テスト進捗管理ビューを追加

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -94,6 +94,35 @@ fn save_tasks(app: tauri::AppHandle, json: String) -> Result<(), String> {
     fs::write(dir.join("tasks.json"), json).map_err(|e| e.to_string())
 }
 
+// ── テストブック保存 ──────────────────────────────────────
+
+/// アプリデータディレクトリの testBooks.json を読む。
+#[tauri::command]
+fn load_test_books(app: tauri::AppHandle) -> Result<Option<String>, String> {
+    let path = app
+        .path()
+        .app_data_dir()
+        .map_err(|e| e.to_string())?
+        .join("testBooks.json");
+
+    if path.exists() {
+        fs::read_to_string(&path)
+            .map(Some)
+            .map_err(|e| e.to_string())
+    } else {
+        Ok(None)
+    }
+}
+
+/// テストブック JSON をアプリデータディレクトリの testBooks.json に保存する。
+#[tauri::command]
+fn save_test_books(app: tauri::AppHandle, json: String) -> Result<(), String> {
+    let dir = app.path().app_data_dir().map_err(|e| e.to_string())?;
+
+    fs::create_dir_all(&dir).map_err(|e| e.to_string())?;
+    fs::write(dir.join("testBooks.json"), json).map_err(|e| e.to_string())
+}
+
 // ── 祝日取得 ──────────────────────────────────────────────
 
 /// 内閣府が公開している祝日CSVを取得してパースする。
@@ -225,6 +254,8 @@ pub fn run() {
         .invoke_handler(tauri::generate_handler![
             load_saved_tasks,
             save_tasks,
+            load_test_books,
+            save_test_books,
             fetch_holidays,
             get_proxy_setting,
             save_proxy_setting,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,20 +7,24 @@ import SearchView from "./components/SearchView";
 import AnalysisView from "./components/AnalysisView";
 import ArchiveView from "./components/ArchiveView";
 import NoteView from "./components/NoteView";
+import TestProgressView from "./components/TestProgressView";
 import ProxySettingModal from "./components/ProxySettingModal";
 import UpdateNotifier from "./components/UpdateNotifier";
 import DailyTaskPanel from "./components/DailyTaskPanel";
 import { Task } from "./types/task";
+import { TestBook } from "./types/testBook";
 import { loadTasks, saveTasks } from "./utils/taskStorage";
+import { loadTestBooks, saveTestBooks } from "./utils/testBookStorage";
 import { loadHolidays } from "./utils/holidays";
 import { sortByTree } from "./utils/taskUtils";
 import { exportToExcel } from "./utils/exportToExcel";
 import { useReminder } from "./hooks/useReminder";
 
-type ViewMode = "gantt" | "kanban" | "analysis" | "archive" | "note";
+type ViewMode = "gantt" | "kanban" | "analysis" | "archive" | "note" | "test";
 
 function App() {
   const [tasks, setTasks] = useState<Task[]>([]);
+  const [testBooks, setTestBooks] = useState<TestBook[]>([]);
   const [holidays, setHolidays] = useState<Map<string, string>>(new Map());
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -47,17 +51,19 @@ function App() {
     localStorage.setItem("theme", darkMode ? "dark" : "light");
   }, [darkMode]);
 
-  // 起動時: タスク（保存済み or デフォルト）と祝日を並列ロード
+  // 起動時: タスク・テストブック・祝日を並列ロード
   useEffect(() => {
     Promise.all([
       loadTasks(),
+      loadTestBooks(),
       loadHolidays().catch((e) => {
         setHolidayError(e instanceof Error ? e.message : String(e));
         return new Map<string, string>();
       }),
     ])
-      .then(([loadedTasks, loadedHolidays]) => {
+      .then(([loadedTasks, loadedBooks, loadedHolidays]) => {
         setTasks(sortByTree(loadedTasks));
+        setTestBooks(loadedBooks);
         setHolidays(loadedHolidays);
       })
       .catch((e) => setError(e instanceof Error ? e.message : String(e)))
@@ -85,6 +91,11 @@ function App() {
     const sorted = sortByTree(updated);
     setTasks(sorted);
     void saveTasks(sorted).catch((e) => console.error("タスクの保存に失敗:", e));
+  }
+
+  function handleTestBooksChange(updated: TestBook[]) {
+    setTestBooks(updated);
+    void saveTestBooks(updated).catch((e) => console.error("テストブックの保存に失敗:", e));
   }
 
   /** エクスポート結果トーストを表示し、指定 ms 後に自動で閉じる */
@@ -210,6 +221,16 @@ function App() {
           >
             📝 ノート
           </button>
+          <button
+            className={`view-toggle-btn${viewMode === "test" ? " view-toggle-btn--active" : ""}`}
+            onClick={() => {
+              setViewMode("test");
+              setSearchQuery("");
+            }}
+            title="テスト進捗"
+          >
+            🧪 テスト進捗
+          </button>
         </div>
 
         {/* デイリーTODOパネル切替ボタン */}
@@ -305,6 +326,15 @@ function App() {
             )}
             {!isSearching && viewMode === "note" && (
               <NoteView tasks={tasks} onTasksChange={handleTasksChange} />
+            )}
+            {!isSearching && viewMode === "test" && (
+              <TestProgressView
+                tasks={tasks}
+                testBooks={testBooks}
+                onTestBooksChange={handleTestBooksChange}
+                onTasksChange={handleTasksChange}
+                holidays={holidays}
+              />
             )}
           </>
         )}

--- a/src/components/TestProgressView.tsx
+++ b/src/components/TestProgressView.tsx
@@ -144,7 +144,13 @@ function getTaskDepth(taskId: string, tasks: Task[]): number {
   return 1 + getTaskDepth(task.parentId, tasks);
 }
 
-export default function TestProgressView({ tasks, testBooks, onTestBooksChange, onTasksChange, holidays = new Map() }: Props) {
+export default function TestProgressView({
+  tasks,
+  testBooks,
+  onTestBooksChange,
+  onTasksChange,
+  holidays = new Map(),
+}: Props) {
   const [filterTaskId, setFilterTaskId] = useState<string>("");
   const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set());
 
@@ -167,7 +173,8 @@ export default function TestProgressView({ tasks, testBooks, onTestBooksChange, 
     (s, b) => s + Math.max(0, b.totalCount - sumPass(b.dailyLogs) - sumFail(b.dailyLogs)),
     0,
   );
-  const executedRate = totalCount > 0 ? Math.round(((passCount + failCount) / totalCount) * 100) : 0;
+  const executedRate =
+    totalCount > 0 ? Math.round(((passCount + failCount) / totalCount) * 100) : 0;
   const passRate = totalCount > 0 ? Math.round((passCount / totalCount) * 100) : 0;
 
   function updateBook(id: string, patch: Partial<TestBook>) {
@@ -240,7 +247,9 @@ export default function TestProgressView({ tasks, testBooks, onTestBooksChange, 
               const prefix = depth > 0 ? "└ " : "";
               return (
                 <option key={t.id} value={t.id}>
-                  {indent}{prefix}{t.name}
+                  {indent}
+                  {prefix}
+                  {t.name}
                 </option>
               );
             })}
@@ -259,7 +268,9 @@ export default function TestProgressView({ tasks, testBooks, onTestBooksChange, 
             <span className="test-summary-pass">合格: {passCount}</span>
             <span className="test-summary-fail">不合格: {failCount}</span>
             <span className="test-summary-not">未実施: {notExecuted}</span>
-            <span className="test-summary-rate">実施率: {executedRate}% / 合格率: {passRate}%</span>
+            <span className="test-summary-rate">
+              実施率: {executedRate}% / 合格率: {passRate}%
+            </span>
           </div>
           <div className="test-progress-summary-bar">
             <div className="test-summary-bar-pass" style={{ width: `${passRate}%` }} />
@@ -302,9 +313,7 @@ export default function TestProgressView({ tasks, testBooks, onTestBooksChange, 
                 const fail = sumFail(book.dailyLogs);
                 const notEx = Math.max(0, book.totalCount - pass - fail);
                 const rate =
-                  book.totalCount > 0
-                    ? Math.round(((pass + fail) / book.totalCount) * 100)
-                    : 0;
+                  book.totalCount > 0 ? Math.round(((pass + fail) / book.totalCount) * 100) : 0;
                 const passRateBook =
                   book.totalCount > 0 ? Math.round((pass / book.totalCount) * 100) : 0;
                 const isExpanded = expandedIds.has(book.id);
@@ -357,7 +366,9 @@ export default function TestProgressView({ tasks, testBooks, onTestBooksChange, 
                             const prefix = depth > 0 ? "└ " : "";
                             return (
                               <option key={t.id} value={t.id}>
-                                {indent}{prefix}{t.name}
+                                {indent}
+                                {prefix}
+                                {t.name}
                               </option>
                             );
                           })}
@@ -448,7 +459,9 @@ export default function TestProgressView({ tasks, testBooks, onTestBooksChange, 
                                   <tr>
                                     <th className="tpt-log-label-col"></th>
                                     {book.dailyLogs.map((log) => {
-                                      const { label, isSaturday, isSunday } = getDayOfWeek(log.date);
+                                      const { label, isSaturday, isSunday } = getDayOfWeek(
+                                        log.date,
+                                      );
                                       const holidayName = getHolidayName(log.date, holidays);
                                       const isRed = isSunday || !!holidayName;
                                       const [, m, d] = log.date.split("-");
@@ -459,8 +472,12 @@ export default function TestProgressView({ tasks, testBooks, onTestBooksChange, 
                                           title={holidayName || undefined}
                                         >
                                           <div className="tpt-log-date-head">
-                                            <span className="tpt-log-date-num">{Number(m)}/{Number(d)}</span>
-                                            <span className={`tpt-log-weekday${isRed ? " tpt-log-weekday--sunday" : isSaturday ? " tpt-log-weekday--saturday" : ""}`}>
+                                            <span className="tpt-log-date-num">
+                                              {Number(m)}/{Number(d)}
+                                            </span>
+                                            <span
+                                              className={`tpt-log-weekday${isRed ? " tpt-log-weekday--sunday" : isSaturday ? " tpt-log-weekday--saturday" : ""}`}
+                                            >
                                               {holidayName ? "祝" : label}
                                             </span>
                                             <button
@@ -478,12 +495,24 @@ export default function TestProgressView({ tasks, testBooks, onTestBooksChange, 
                                 </thead>
                                 <tbody>
                                   <tr>
-                                    <td className="tpt-log-row-label tpt-log-row-label--pass">合格数</td>
+                                    <td className="tpt-log-row-label tpt-log-row-label--pass">
+                                      合格数
+                                    </td>
                                     {book.dailyLogs.map((log) => {
                                       const { isSaturday, isSunday } = getDayOfWeek(log.date);
-                                      const isRed = isSunday || !!getHolidayName(log.date, holidays);
+                                      const isRed =
+                                        isSunday || !!getHolidayName(log.date, holidays);
                                       return (
-                                        <td key={log.date} className={isRed ? "tpt-log-cell--sunday" : isSaturday ? "tpt-log-cell--saturday" : ""}>
+                                        <td
+                                          key={log.date}
+                                          className={
+                                            isRed
+                                              ? "tpt-log-cell--sunday"
+                                              : isSaturday
+                                                ? "tpt-log-cell--saturday"
+                                                : ""
+                                          }
+                                        >
                                           <input
                                             type="number"
                                             className="tpt-log-input-cell tpt-log-input--pass"
@@ -501,12 +530,24 @@ export default function TestProgressView({ tasks, testBooks, onTestBooksChange, 
                                     })}
                                   </tr>
                                   <tr>
-                                    <td className="tpt-log-row-label tpt-log-row-label--fail">不合格数</td>
+                                    <td className="tpt-log-row-label tpt-log-row-label--fail">
+                                      不合格数
+                                    </td>
                                     {book.dailyLogs.map((log) => {
                                       const { isSaturday, isSunday } = getDayOfWeek(log.date);
-                                      const isRed = isSunday || !!getHolidayName(log.date, holidays);
+                                      const isRed =
+                                        isSunday || !!getHolidayName(log.date, holidays);
                                       return (
-                                        <td key={log.date} className={isRed ? "tpt-log-cell--sunday" : isSaturday ? "tpt-log-cell--saturday" : ""}>
+                                        <td
+                                          key={log.date}
+                                          className={
+                                            isRed
+                                              ? "tpt-log-cell--sunday"
+                                              : isSaturday
+                                                ? "tpt-log-cell--saturday"
+                                                : ""
+                                          }
+                                        >
                                           <input
                                             type="number"
                                             className="tpt-log-input-cell tpt-log-input--fail"
@@ -526,10 +567,7 @@ export default function TestProgressView({ tasks, testBooks, onTestBooksChange, 
                                 </tbody>
                               </table>
                             </div>
-                            <button
-                              className="tpt-log-add-row"
-                              onClick={() => addLogRow(book)}
-                            >
+                            <button className="tpt-log-add-row" onClick={() => addLogRow(book)}>
                               + 今日の列を追加
                             </button>
                           </div>

--- a/src/components/TestProgressView.tsx
+++ b/src/components/TestProgressView.tsx
@@ -1,0 +1,548 @@
+import { useEffect, useRef, useState } from "react";
+import { Task } from "../types/task";
+import { DailyLog, TestBook } from "../types/testBook";
+
+interface Props {
+  tasks: Task[];
+  testBooks: TestBook[];
+  onTestBooksChange: (books: TestBook[]) => void;
+  onTasksChange: (tasks: Task[]) => void;
+  holidays?: Map<string, string>;
+}
+
+function AssigneeCombobox({
+  value,
+  onChange,
+  suggestions,
+}: {
+  value: string;
+  onChange: (v: string) => void;
+  suggestions: string[];
+}) {
+  const [open, setOpen] = useState(false);
+  const [activeIndex, setActiveIndex] = useState(-1);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const filtered = suggestions.filter((s) => s.toLowerCase().includes(value.toLowerCase()));
+
+  useEffect(() => {
+    function handleClickOutside(e: MouseEvent) {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    }
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, []);
+
+  return (
+    <div className="combobox-wrapper" ref={containerRef}>
+      <input
+        type="text"
+        value={value}
+        onChange={(e) => {
+          onChange(e.target.value);
+          setOpen(true);
+          setActiveIndex(-1);
+        }}
+        onFocus={() => setOpen(true)}
+        placeholder="-"
+        className="tpt-input assignee-input"
+        autoComplete="off"
+        onKeyDown={(e) => {
+          if (e.key === "ArrowDown") {
+            e.preventDefault();
+            setActiveIndex((i) => Math.min(i + 1, filtered.length - 1));
+          } else if (e.key === "ArrowUp") {
+            e.preventDefault();
+            setActiveIndex((i) => Math.max(i - 1, -1));
+          } else if (e.key === "Enter" && activeIndex >= 0) {
+            e.preventDefault();
+            onChange(filtered[activeIndex]);
+            setOpen(false);
+            setActiveIndex(-1);
+          } else if (e.key === "Escape") {
+            setOpen(false);
+          }
+        }}
+      />
+      {open && filtered.length > 0 && (
+        <ul className="combobox-dropdown">
+          {filtered.map((s, i) => (
+            <li
+              key={s}
+              className={`combobox-option${i === activeIndex ? " active" : ""}`}
+              onMouseDown={() => {
+                onChange(s);
+                setOpen(false);
+                setActiveIndex(-1);
+              }}
+            >
+              {s}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+const WEEKDAYS = ["日", "月", "火", "水", "木", "金", "土"];
+
+function getDayOfWeek(dateStr: string): { label: string; isSaturday: boolean; isSunday: boolean } {
+  const [y, m, d] = dateStr.split("-").map(Number);
+  const day = new Date(y, m - 1, d).getDay();
+  return { label: WEEKDAYS[day], isSaturday: day === 6, isSunday: day === 0 };
+}
+
+function getHolidayName(dateStr: string, holidays: Map<string, string>): string {
+  const [y, m, d] = dateStr.split("-").map(Number);
+  return holidays.get(`${y}/${m}/${d}`) ?? "";
+}
+
+function today(): string {
+  const d = new Date();
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+}
+
+function newBook(): TestBook {
+  return {
+    id: crypto.randomUUID(),
+    name: "",
+    totalCount: 0,
+    dailyLogs: [],
+  };
+}
+
+function buildLogsFromTask(task: Task): DailyLog[] {
+  const logs: DailyLog[] = [];
+  const cur = new Date(task.startDate);
+  cur.setHours(0, 0, 0, 0);
+  const end = new Date(task.endDate);
+  end.setHours(0, 0, 0, 0);
+  while (cur <= end) {
+    const y = cur.getFullYear();
+    const m = String(cur.getMonth() + 1).padStart(2, "0");
+    const d = String(cur.getDate()).padStart(2, "0");
+    logs.push({ date: `${y}-${m}-${d}`, passCount: 0, failCount: 0 });
+    cur.setDate(cur.getDate() + 1);
+  }
+  return logs;
+}
+
+function sumPass(logs: DailyLog[]): number {
+  return logs.reduce((s, l) => s + l.passCount, 0);
+}
+
+function sumFail(logs: DailyLog[]): number {
+  return logs.reduce((s, l) => s + l.failCount, 0);
+}
+
+function getTaskDepth(taskId: string, tasks: Task[]): number {
+  const task = tasks.find((t) => t.id === taskId);
+  if (!task?.parentId) return 0;
+  return 1 + getTaskDepth(task.parentId, tasks);
+}
+
+export default function TestProgressView({ tasks, testBooks, onTestBooksChange, onTasksChange, holidays = new Map() }: Props) {
+  const [filterTaskId, setFilterTaskId] = useState<string>("");
+  const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set());
+
+  const selectableTasks = tasks.filter((t) => !t.archived);
+
+  const allMembers = [
+    ...new Set(
+      tasks.flatMap((t) => [t.assignee, ...(t.subMembers ?? [])]).filter((m): m is string => !!m),
+    ),
+  ];
+
+  const visibleBooks = filterTaskId
+    ? testBooks.filter((b) => b.taskId === filterTaskId)
+    : testBooks;
+
+  const totalCount = visibleBooks.reduce((s, b) => s + b.totalCount, 0);
+  const passCount = visibleBooks.reduce((s, b) => s + sumPass(b.dailyLogs), 0);
+  const failCount = visibleBooks.reduce((s, b) => s + sumFail(b.dailyLogs), 0);
+  const notExecuted = visibleBooks.reduce(
+    (s, b) => s + Math.max(0, b.totalCount - sumPass(b.dailyLogs) - sumFail(b.dailyLogs)),
+    0,
+  );
+  const executedRate = totalCount > 0 ? Math.round(((passCount + failCount) / totalCount) * 100) : 0;
+  const passRate = totalCount > 0 ? Math.round((passCount / totalCount) * 100) : 0;
+
+  function updateBook(id: string, patch: Partial<TestBook>) {
+    onTestBooksChange(testBooks.map((b) => (b.id === id ? { ...b, ...patch } : b)));
+  }
+
+  function addBook() {
+    const linked = tasks.find((t) => t.id === filterTaskId);
+    const book: TestBook = {
+      ...newBook(),
+      taskId: filterTaskId || undefined,
+      assignee: linked?.assignee,
+      dueDate: linked ? linked.endDate.toISOString().slice(0, 10) : undefined,
+      dailyLogs: linked ? buildLogsFromTask(linked) : [],
+    };
+    onTestBooksChange([...testBooks, book]);
+    setExpandedIds((prev) => new Set([...prev, book.id]));
+  }
+
+  function deleteBook(id: string) {
+    onTestBooksChange(testBooks.filter((b) => b.id !== id));
+  }
+
+  function toggleExpand(id: string) {
+    setExpandedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }
+
+  function addLogRow(book: TestBook) {
+    const date = today();
+    if (book.dailyLogs.some((l) => l.date === date)) return;
+    const logs = [...book.dailyLogs, { date, passCount: 0, failCount: 0 }].sort((a, b) =>
+      a.date.localeCompare(b.date),
+    );
+    updateBook(book.id, { dailyLogs: logs });
+  }
+
+  function updateLogRow(book: TestBook, date: string, patch: Partial<DailyLog>) {
+    const logs = book.dailyLogs.map((l) => (l.date === date ? { ...l, ...patch } : l));
+    updateBook(book.id, { dailyLogs: logs });
+  }
+
+  function deleteLogRow(book: TestBook, date: string) {
+    updateBook(book.id, { dailyLogs: book.dailyLogs.filter((l) => l.date !== date) });
+  }
+
+  return (
+    <div className="test-progress-view">
+      {/* ヘッダー */}
+      <div className="test-progress-header">
+        <div className="test-progress-title">
+          <span className="test-progress-icon">🧪</span>
+          <h2>テスト進捗</h2>
+          <span className="test-progress-count">{visibleBooks.length} ブック</span>
+        </div>
+        <div className="test-progress-controls">
+          <select
+            className="test-progress-filter"
+            value={filterTaskId}
+            onChange={(e) => setFilterTaskId(e.target.value)}
+          >
+            <option value="">すべてのタスク</option>
+            {selectableTasks.map((t) => {
+              const depth = getTaskDepth(t.id, tasks);
+              const indent = "    ".repeat(depth);
+              const prefix = depth > 0 ? "└ " : "";
+              return (
+                <option key={t.id} value={t.id}>
+                  {indent}{prefix}{t.name}
+                </option>
+              );
+            })}
+          </select>
+          <button className="test-progress-add-btn" onClick={addBook}>
+            + ブック追加
+          </button>
+        </div>
+      </div>
+
+      {/* サマリーバー */}
+      {totalCount > 0 && (
+        <div className="test-progress-summary">
+          <div className="test-progress-summary-stats">
+            <span className="test-summary-total">総件数: {totalCount}</span>
+            <span className="test-summary-pass">合格: {passCount}</span>
+            <span className="test-summary-fail">不合格: {failCount}</span>
+            <span className="test-summary-not">未実施: {notExecuted}</span>
+            <span className="test-summary-rate">実施率: {executedRate}% / 合格率: {passRate}%</span>
+          </div>
+          <div className="test-progress-summary-bar">
+            <div className="test-summary-bar-pass" style={{ width: `${passRate}%` }} />
+            <div
+              className="test-summary-bar-fail"
+              style={{ width: `${Math.round((failCount / totalCount) * 100)}%` }}
+            />
+          </div>
+        </div>
+      )}
+
+      {/* テーブル */}
+      {visibleBooks.length === 0 ? (
+        <div className="test-progress-empty">
+          <span className="test-progress-empty-icon">📋</span>
+          <p>テストブックがありません</p>
+          <p className="test-progress-empty-hint">「+ ブック追加」からブックを登録してください</p>
+        </div>
+      ) : (
+        <div className="test-progress-table-wrap">
+          <table className="test-progress-table">
+            <thead>
+              <tr>
+                <th className="tpt-expand"></th>
+                <th className="tpt-name">ブック名</th>
+                <th className="tpt-task">WBSタスク</th>
+                <th className="tpt-assignee">担当者</th>
+                <th className="tpt-due">期限</th>
+                <th className="tpt-total">総件数</th>
+                <th className="tpt-pass">合格</th>
+                <th className="tpt-fail">不合格</th>
+                <th className="tpt-not">未実施</th>
+                <th className="tpt-bar">進捗</th>
+                <th className="tpt-del"></th>
+              </tr>
+            </thead>
+            <tbody>
+              {visibleBooks.map((book) => {
+                const pass = sumPass(book.dailyLogs);
+                const fail = sumFail(book.dailyLogs);
+                const notEx = Math.max(0, book.totalCount - pass - fail);
+                const rate =
+                  book.totalCount > 0
+                    ? Math.round(((pass + fail) / book.totalCount) * 100)
+                    : 0;
+                const passRateBook =
+                  book.totalCount > 0 ? Math.round((pass / book.totalCount) * 100) : 0;
+                const isExpanded = expandedIds.has(book.id);
+
+                return (
+                  <>
+                    <tr key={book.id} className="test-progress-row">
+                      <td className="tpt-expand">
+                        <button
+                          className="tpt-expand-btn"
+                          onClick={() => toggleExpand(book.id)}
+                          title={isExpanded ? "折りたたむ" : "日次ログを展開"}
+                        >
+                          {isExpanded ? "▼" : "▶"}
+                        </button>
+                      </td>
+                      <td className="tpt-name">
+                        <input
+                          className="tpt-input tpt-input--name"
+                          value={book.name}
+                          placeholder="ブック名"
+                          onChange={(e) => updateBook(book.id, { name: e.target.value })}
+                        />
+                      </td>
+                      <td className="tpt-task">
+                        <select
+                          className="tpt-select"
+                          value={book.taskId ?? ""}
+                          onChange={(e) => {
+                            const taskId = e.target.value || undefined;
+                            const linked = tasks.find((t) => t.id === taskId);
+                            updateBook(book.id, {
+                              taskId,
+                              ...(linked?.assignee && !book.assignee
+                                ? { assignee: linked.assignee }
+                                : {}),
+                              ...(linked?.endDate && !book.dueDate
+                                ? { dueDate: linked.endDate.toISOString().slice(0, 10) }
+                                : {}),
+                              ...(linked && book.dailyLogs.length === 0
+                                ? { dailyLogs: buildLogsFromTask(linked) }
+                                : {}),
+                            });
+                          }}
+                        >
+                          <option value="">-</option>
+                          {selectableTasks.map((t) => {
+                            const depth = getTaskDepth(t.id, tasks);
+                            const indent = "    ".repeat(depth);
+                            const prefix = depth > 0 ? "└ " : "";
+                            return (
+                              <option key={t.id} value={t.id}>
+                                {indent}{prefix}{t.name}
+                              </option>
+                            );
+                          })}
+                        </select>
+                      </td>
+                      <td className="tpt-assignee">
+                        <AssigneeCombobox
+                          value={book.assignee ?? ""}
+                          onChange={(v) => updateBook(book.id, { assignee: v || undefined })}
+                          suggestions={allMembers}
+                        />
+                      </td>
+                      <td className="tpt-due">
+                        <input
+                          type="date"
+                          className="tpt-input tpt-input--date"
+                          value={book.dueDate ?? ""}
+                          onChange={(e) =>
+                            updateBook(book.id, { dueDate: e.target.value || undefined })
+                          }
+                        />
+                      </td>
+                      <td className="tpt-total">
+                        <input
+                          type="number"
+                          className="tpt-input tpt-input--num"
+                          value={book.totalCount || ""}
+                          min={0}
+                          placeholder="0"
+                          onChange={(e) =>
+                            updateBook(book.id, { totalCount: parseInt(e.target.value, 10) || 0 })
+                          }
+                        />
+                      </td>
+                      <td className="tpt-pass tpt-derived">{pass}</td>
+                      <td className="tpt-fail tpt-derived">{fail}</td>
+                      <td className="tpt-not tpt-derived">{notEx}</td>
+                      <td className="tpt-bar">
+                        <div className="tpt-bar-wrap">
+                          <div className="tpt-bar-track">
+                            <div className="tpt-bar-pass" style={{ width: `${passRateBook}%` }} />
+                            <div
+                              className="tpt-bar-fail"
+                              style={{
+                                width: `${book.totalCount > 0 ? Math.round((fail / book.totalCount) * 100) : 0}%`,
+                              }}
+                            />
+                          </div>
+                          <span className="tpt-bar-pct">{rate}%</span>
+                        </div>
+                      </td>
+                      <td className="tpt-sync">
+                        {book.taskId && (
+                          <button
+                            className="tpt-sync-btn"
+                            onClick={() => {
+                              onTasksChange(
+                                tasks.map((t) =>
+                                  t.id === book.taskId ? { ...t, progress: rate } : t,
+                                ),
+                              );
+                            }}
+                            title={`実施率 ${rate}% をタスクの進捗率に反映`}
+                          >
+                            ↑ 反映
+                          </button>
+                        )}
+                      </td>
+                      <td className="tpt-del">
+                        <button
+                          className="tpt-del-btn"
+                          onClick={() => deleteBook(book.id)}
+                          title="削除"
+                        >
+                          🗑
+                        </button>
+                      </td>
+                    </tr>
+
+                    {/* 日次ログテーブル（横方向に日付が並ぶ転置レイアウト） */}
+                    {isExpanded && (
+                      <tr key={`${book.id}-log`} className="test-progress-log-row">
+                        <td colSpan={12}>
+                          <div className="tpt-log-area">
+                            <div className="tpt-log-scroll">
+                              <table className="tpt-log-table">
+                                <thead>
+                                  <tr>
+                                    <th className="tpt-log-label-col"></th>
+                                    {book.dailyLogs.map((log) => {
+                                      const { label, isSaturday, isSunday } = getDayOfWeek(log.date);
+                                      const holidayName = getHolidayName(log.date, holidays);
+                                      const isRed = isSunday || !!holidayName;
+                                      const [, m, d] = log.date.split("-");
+                                      return (
+                                        <th
+                                          key={log.date}
+                                          className={`tpt-log-date-col${isRed ? " tpt-log-date-col--sunday" : isSaturday ? " tpt-log-date-col--saturday" : ""}`}
+                                          title={holidayName || undefined}
+                                        >
+                                          <div className="tpt-log-date-head">
+                                            <span className="tpt-log-date-num">{Number(m)}/{Number(d)}</span>
+                                            <span className={`tpt-log-weekday${isRed ? " tpt-log-weekday--sunday" : isSaturday ? " tpt-log-weekday--saturday" : ""}`}>
+                                              {holidayName ? "祝" : label}
+                                            </span>
+                                            <button
+                                              className="tpt-log-del-btn"
+                                              onClick={() => deleteLogRow(book, log.date)}
+                                              title="この列を削除"
+                                            >
+                                              ✕
+                                            </button>
+                                          </div>
+                                        </th>
+                                      );
+                                    })}
+                                  </tr>
+                                </thead>
+                                <tbody>
+                                  <tr>
+                                    <td className="tpt-log-row-label tpt-log-row-label--pass">合格数</td>
+                                    {book.dailyLogs.map((log) => {
+                                      const { isSaturday, isSunday } = getDayOfWeek(log.date);
+                                      const isRed = isSunday || !!getHolidayName(log.date, holidays);
+                                      return (
+                                        <td key={log.date} className={isRed ? "tpt-log-cell--sunday" : isSaturday ? "tpt-log-cell--saturday" : ""}>
+                                          <input
+                                            type="number"
+                                            className="tpt-log-input-cell tpt-log-input--pass"
+                                            value={log.passCount || ""}
+                                            min={0}
+                                            placeholder="0"
+                                            onChange={(e) =>
+                                              updateLogRow(book, log.date, {
+                                                passCount: parseInt(e.target.value, 10) || 0,
+                                              })
+                                            }
+                                          />
+                                        </td>
+                                      );
+                                    })}
+                                  </tr>
+                                  <tr>
+                                    <td className="tpt-log-row-label tpt-log-row-label--fail">不合格数</td>
+                                    {book.dailyLogs.map((log) => {
+                                      const { isSaturday, isSunday } = getDayOfWeek(log.date);
+                                      const isRed = isSunday || !!getHolidayName(log.date, holidays);
+                                      return (
+                                        <td key={log.date} className={isRed ? "tpt-log-cell--sunday" : isSaturday ? "tpt-log-cell--saturday" : ""}>
+                                          <input
+                                            type="number"
+                                            className="tpt-log-input-cell tpt-log-input--fail"
+                                            value={log.failCount || ""}
+                                            min={0}
+                                            placeholder="0"
+                                            onChange={(e) =>
+                                              updateLogRow(book, log.date, {
+                                                failCount: parseInt(e.target.value, 10) || 0,
+                                              })
+                                            }
+                                          />
+                                        </td>
+                                      );
+                                    })}
+                                  </tr>
+                                </tbody>
+                              </table>
+                            </div>
+                            <button
+                              className="tpt-log-add-row"
+                              onClick={() => addLogRow(book)}
+                            >
+                              + 今日の列を追加
+                            </button>
+                          </div>
+                        </td>
+                      </tr>
+                    )}
+                  </>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -4235,3 +4235,456 @@
   background: #3a2020;
   color: #e55;
 }
+
+/* ── TestProgressView ────────────────────────────────────── */
+
+.test-progress-view {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  background: #f0f2f5;
+  overflow: hidden;
+}
+
+.test-progress-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 20px;
+  background: #fff;
+  border-bottom: 1px solid #e0e3ea;
+  flex-shrink: 0;
+  gap: 12px;
+}
+
+.test-progress-title {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.test-progress-icon { font-size: 1.4rem; }
+
+.test-progress-title h2 {
+  margin: 0;
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: #1a1a2e;
+}
+
+.test-progress-count {
+  font-size: 0.82rem;
+  color: #666;
+  background: #f0f2f5;
+  padding: 2px 8px;
+  border-radius: 10px;
+}
+
+.test-progress-controls {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.test-progress-filter {
+  padding: 5px 10px;
+  border: 1px solid #d0d3db;
+  border-radius: 6px;
+  font-size: 0.84rem;
+  color: #333;
+  background: #fff;
+  cursor: pointer;
+}
+
+.test-progress-add-btn {
+  padding: 6px 14px;
+  background: #4a90d9;
+  color: #fff;
+  border: none;
+  border-radius: 6px;
+  font-size: 0.84rem;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background 0.15s;
+}
+.test-progress-add-btn:hover { background: #357abd; }
+
+.test-progress-summary {
+  padding: 10px 20px;
+  background: #fff;
+  border-bottom: 1px solid #e0e3ea;
+  flex-shrink: 0;
+}
+
+.test-progress-summary-stats {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  font-size: 0.84rem;
+  margin-bottom: 6px;
+  flex-wrap: wrap;
+}
+
+.test-summary-total { color: #555; }
+.test-summary-pass { color: #27ae60; font-weight: 600; }
+.test-summary-fail { color: #e74c3c; font-weight: 600; }
+.test-summary-not { color: #999; }
+.test-summary-rate { color: #4a90d9; margin-left: auto; font-weight: 500; }
+
+.test-progress-summary-bar {
+  height: 8px;
+  background: #e8eaf0;
+  border-radius: 4px;
+  overflow: hidden;
+  display: flex;
+}
+
+.test-summary-bar-pass { height: 100%; background: #27ae60; transition: width 0.3s; }
+.test-summary-bar-fail { height: 100%; background: #e74c3c; transition: width 0.3s; }
+
+.test-progress-empty {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  color: #aaa;
+}
+.test-progress-empty-icon { font-size: 3rem; }
+.test-progress-empty p { font-size: 1rem; }
+.test-progress-empty-hint { font-size: 0.82rem; color: #bbb; }
+
+.test-progress-table-wrap {
+  flex: 1;
+  overflow: auto;
+  padding: 16px 20px;
+}
+
+.test-progress-table {
+  width: 100%;
+  border-collapse: collapse;
+  background: #fff;
+  border-radius: 8px;
+  overflow: hidden;
+  box-shadow: 0 1px 4px rgba(0,0,0,0.07);
+  font-size: 0.84rem;
+}
+
+.test-progress-table thead tr {
+  background: #f5f6fa;
+  border-bottom: 2px solid #e0e3ea;
+}
+
+.test-progress-table th {
+  padding: 8px 10px;
+  text-align: left;
+  font-weight: 600;
+  color: #555;
+  white-space: nowrap;
+}
+
+.test-progress-row td {
+  padding: 6px 10px;
+  border-bottom: 1px solid #f0f2f5;
+  vertical-align: middle;
+}
+.test-progress-row:last-child td { border-bottom: none; }
+.test-progress-row:hover td { background: #f8f9fc; }
+
+.tpt-expand { width: 28px; }
+.tpt-name { min-width: 160px; }
+.tpt-task { min-width: 120px; }
+.tpt-assignee { width: 90px; }
+.tpt-due { width: 120px; }
+.tpt-total, .tpt-pass, .tpt-fail { width: 64px; }
+.tpt-not { width: 56px; }
+.tpt-bar { min-width: 100px; }
+.tpt-del { width: 36px; }
+
+.tpt-derived { color: #555; text-align: right; font-size: 0.84rem; padding-right: 14px; }
+.tpt-not.tpt-derived { color: #999; }
+
+.tpt-input {
+  width: 100%;
+  padding: 3px 6px;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  font-size: 0.84rem;
+  background: transparent;
+  color: inherit;
+  transition: border-color 0.15s, background 0.15s;
+}
+.tpt-input:hover, .tpt-input:focus {
+  border-color: #c0c4d0;
+  background: #f5f6fa;
+  outline: none;
+}
+.tpt-input--name { font-weight: 500; }
+.tpt-input--num { text-align: right; width: 56px; }
+.tpt-input--pass:focus { border-color: #27ae60; }
+.tpt-input--fail:focus { border-color: #e74c3c; }
+.tpt-input--date { width: 110px; font-size: 0.8rem; }
+
+.tpt-select {
+  width: 100%;
+  padding: 3px 6px;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  font-size: 0.82rem;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+}
+.tpt-select:hover, .tpt-select:focus {
+  border-color: #c0c4d0;
+  background: #f5f6fa;
+  outline: none;
+}
+
+.tpt-bar-wrap { display: flex; align-items: center; gap: 6px; }
+.tpt-bar-track {
+  flex: 1;
+  height: 8px;
+  background: #e8eaf0;
+  border-radius: 4px;
+  overflow: hidden;
+  display: flex;
+}
+.tpt-bar-pass { height: 100%; background: #27ae60; transition: width 0.2s; }
+.tpt-bar-fail { height: 100%; background: #e74c3c; transition: width 0.2s; }
+.tpt-bar-pct { font-size: 0.78rem; color: #888; width: 32px; text-align: right; flex-shrink: 0; }
+
+.tpt-expand-btn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 0.7rem;
+  color: #888;
+  padding: 2px 4px;
+  border-radius: 3px;
+}
+.tpt-expand-btn:hover { background: #e8eaf0; color: #444; }
+
+.tpt-del-btn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 0.9rem;
+  padding: 3px 5px;
+  border-radius: 4px;
+  opacity: 0.4;
+  transition: opacity 0.15s, background 0.15s;
+}
+.tpt-del-btn:hover { opacity: 1; background: #fdf0ef; }
+
+.tpt-sync { width: 64px; text-align: center; }
+.tpt-sync-btn {
+  padding: 3px 8px;
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: #1e88e5;
+  background: #e8f4fd;
+  border: 1px solid #90caf9;
+  border-radius: 4px;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background 0.15s, border-color 0.15s;
+}
+.tpt-sync-btn:hover { background: #bbdefb; border-color: #42a5f5; }
+
+/* 日次ログテーブル */
+.test-progress-log-row td {
+  padding: 8px 16px 12px 40px;
+  background: #f5f7fb;
+  border-bottom: 1px solid #e8eaf0;
+  /* テーブルセルがログテーブルの幅で広がらないよう制約 */
+  max-width: 0;
+  overflow: hidden;
+}
+
+.tpt-log-area {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  min-width: 0;
+  overflow: hidden;
+}
+
+.tpt-log-scroll {
+  overflow-x: auto;
+  overflow-y: visible;
+}
+
+.tpt-log-table {
+  border-collapse: collapse;
+  font-size: 0.84rem;
+  background: #fff;
+  border-radius: 6px;
+  overflow: hidden;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.06);
+}
+
+.tpt-log-table thead tr {
+  background: #eef0f6;
+}
+
+.tpt-log-table th {
+  padding: 6px 6px 4px;
+  font-weight: 600;
+  color: #666;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.tpt-log-entry td {
+  padding: 4px 4px;
+  border-top: 1px solid #f0f2f5;
+  vertical-align: middle;
+}
+
+.tpt-log-label-col { width: 72px; min-width: 72px; }
+
+.tpt-log-date-col {
+  min-width: 84px;
+  width: 84px;
+  text-align: center;
+  padding: 6px 4px 4px;
+}
+.tpt-log-date-col--saturday { background: #f0f7ff; }
+.tpt-log-date-col--sunday   { background: #fff0f0; }
+
+.tpt-log-date-head {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+}
+
+.tpt-log-date-num {
+  font-size: 0.82rem;
+  font-weight: 600;
+  color: #444;
+  white-space: nowrap;
+}
+
+.tpt-log-weekday {
+  font-size: 0.74rem;
+  font-weight: 600;
+  color: #888;
+}
+.tpt-log-weekday--saturday { color: #1e88e5; }
+.tpt-log-weekday--sunday   { color: #e53935; }
+
+.tpt-log-row-label {
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: #666;
+  white-space: nowrap;
+  padding: 6px 10px;
+  text-align: right;
+}
+.tpt-log-row-label--pass { color: #27ae60; }
+.tpt-log-row-label--fail { color: #e74c3c; }
+
+.tpt-log-cell--saturday { background: #f0f7ff; }
+.tpt-log-cell--sunday   { background: #fff0f0; }
+
+.tpt-log-input-cell {
+  width: 72px;
+  padding: 5px 6px;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  text-align: center;
+  font-size: 0.84rem;
+  background: transparent;
+  color: inherit;
+  transition: border-color 0.15s, background 0.15s;
+}
+.tpt-log-input-cell:hover, .tpt-log-input-cell:focus {
+  border-color: #c0c4d0;
+  background: #f5f6fa;
+  outline: none;
+}
+.tpt-log-input--pass:focus { border-color: #27ae60; }
+.tpt-log-input--fail:focus { border-color: #e74c3c; }
+
+.tpt-log-del-btn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 0.68rem;
+  padding: 1px 3px;
+  border-radius: 3px;
+  opacity: 0.3;
+  color: #888;
+  transition: opacity 0.15s, background 0.15s;
+}
+.tpt-log-del-btn:hover { opacity: 1; background: #fdf0ef; color: #e74c3c; }
+
+.tpt-log-add-row {
+  align-self: flex-start;
+  padding: 4px 12px;
+  background: none;
+  border: 1px dashed #b0b4c4;
+  border-radius: 5px;
+  font-size: 0.8rem;
+  color: #777;
+  cursor: pointer;
+  transition: border-color 0.15s, color 0.15s, background 0.15s;
+}
+.tpt-log-add-row:hover { border-color: #4a90d9; color: #4a90d9; background: #eef4fc; }
+
+/* ── Dark mode: TestProgressView ── */
+
+[data-theme="dark"] .test-progress-view { background: #121318; }
+[data-theme="dark"] .test-progress-header { background: #1e2028; border-bottom-color: #353845; }
+[data-theme="dark"] .test-progress-title h2 { color: #e2e4f0; }
+[data-theme="dark"] .test-progress-count { background: #2a2d38; color: #6e7080; }
+[data-theme="dark"] .test-progress-filter { background: #2a2d38; border-color: #353845; color: #c0c3d0; }
+[data-theme="dark"] .test-progress-summary { background: #1e2028; border-bottom-color: #353845; }
+[data-theme="dark"] .test-summary-total { color: #a0a3b0; }
+[data-theme="dark"] .test-summary-not { color: #666; }
+[data-theme="dark"] .test-progress-summary-bar { background: #2a2d38; }
+[data-theme="dark"] .test-progress-table { background: #1e2028; box-shadow: none; }
+[data-theme="dark"] .test-progress-table thead tr { background: #252830; border-bottom-color: #353845; }
+[data-theme="dark"] .test-progress-table th { color: #8a8da0; }
+[data-theme="dark"] .test-progress-row td { border-bottom-color: #2a2d38; }
+[data-theme="dark"] .test-progress-row:hover td { background: #252830; }
+[data-theme="dark"] .tpt-not--val { color: #666; }
+[data-theme="dark"] .tpt-input { color: #c0c3d0; }
+[data-theme="dark"] .tpt-input:hover, [data-theme="dark"] .tpt-input:focus { border-color: #454860; background: #252830; }
+[data-theme="dark"] .tpt-select { color: #c0c3d0; }
+[data-theme="dark"] .tpt-select:hover, [data-theme="dark"] .tpt-select:focus { border-color: #454860; background: #252830; }
+[data-theme="dark"] .tpt-bar-track { background: #2a2d38; }
+[data-theme="dark"] .tpt-bar-pct { color: #666; }
+[data-theme="dark"] .tpt-expand-btn { color: #666; }
+[data-theme="dark"] .tpt-expand-btn:hover { background: #2a2d38; color: #c0c3d0; }
+[data-theme="dark"] .tpt-derived { color: #8a8da0; }
+[data-theme="dark"] .tpt-not.tpt-derived { color: #555; }
+[data-theme="dark"] .tpt-del-btn:hover { background: #3a1a1a; }
+[data-theme="dark"] .tpt-sync-btn { color: #64b5f6; background: #1a2535; border-color: #1e3a5f; }
+[data-theme="dark"] .tpt-sync-btn:hover { background: #1e3a5f; border-color: #42a5f5; }
+[data-theme="dark"] .test-progress-log-row td { background: #191b22; border-bottom-color: #2a2d38; }
+[data-theme="dark"] .tpt-log-table { background: #1e2028; }
+[data-theme="dark"] .tpt-log-table thead tr { background: #252830; }
+[data-theme="dark"] .tpt-log-table th { color: #6e7080; }
+[data-theme="dark"] .tpt-log-entry td { border-top-color: #2a2d38; }
+[data-theme="dark"] .tpt-log-input-cell { color: #c0c3d0; }
+[data-theme="dark"] .tpt-log-input-cell:hover, [data-theme="dark"] .tpt-log-input-cell:focus { border-color: #454860; background: #252830; }
+[data-theme="dark"] .tpt-log-del-btn:hover { background: #3a1a1a; }
+[data-theme="dark"] .tpt-log-weekday { color: #555; }
+[data-theme="dark"] .tpt-log-weekday--saturday { color: #64b5f6; }
+[data-theme="dark"] .tpt-log-weekday--sunday   { color: #f44336; }
+[data-theme="dark"] .tpt-log-date-col--saturday { background: #1a2030; }
+[data-theme="dark"] .tpt-log-date-col--sunday   { background: #2a1818; }
+[data-theme="dark"] .tpt-log-cell--saturday { background: #1a2030; }
+[data-theme="dark"] .tpt-log-cell--sunday   { background: #2a1818; }
+[data-theme="dark"] .tpt-log-date-num { color: #c0c3d0; }
+[data-theme="dark"] .tpt-log-row-label { color: #6e7080; }
+[data-theme="dark"] .tpt-log-row-label--pass { color: #2ecc71; }
+[data-theme="dark"] .tpt-log-row-label--fail { color: #e74c3c; }
+[data-theme="dark"] .tpt-log-del-btn:hover { background: #3a1a1a; }
+[data-theme="dark"] .tpt-log-add-row { border-color: #454860; color: #6e7080; }
+[data-theme="dark"] .tpt-log-add-row:hover { border-color: #4a90d9; color: #7eb8f5; background: #1a2d45; }

--- a/src/styles.css
+++ b/src/styles.css
@@ -4264,7 +4264,9 @@
   gap: 10px;
 }
 
-.test-progress-icon { font-size: 1.4rem; }
+.test-progress-icon {
+  font-size: 1.4rem;
+}
 
 .test-progress-title h2 {
   margin: 0;
@@ -4308,7 +4310,9 @@
   white-space: nowrap;
   transition: background 0.15s;
 }
-.test-progress-add-btn:hover { background: #357abd; }
+.test-progress-add-btn:hover {
+  background: #357abd;
+}
 
 .test-progress-summary {
   padding: 10px 20px;
@@ -4326,11 +4330,25 @@
   flex-wrap: wrap;
 }
 
-.test-summary-total { color: #555; }
-.test-summary-pass { color: #27ae60; font-weight: 600; }
-.test-summary-fail { color: #e74c3c; font-weight: 600; }
-.test-summary-not { color: #999; }
-.test-summary-rate { color: #4a90d9; margin-left: auto; font-weight: 500; }
+.test-summary-total {
+  color: #555;
+}
+.test-summary-pass {
+  color: #27ae60;
+  font-weight: 600;
+}
+.test-summary-fail {
+  color: #e74c3c;
+  font-weight: 600;
+}
+.test-summary-not {
+  color: #999;
+}
+.test-summary-rate {
+  color: #4a90d9;
+  margin-left: auto;
+  font-weight: 500;
+}
 
 .test-progress-summary-bar {
   height: 8px;
@@ -4340,8 +4358,16 @@
   display: flex;
 }
 
-.test-summary-bar-pass { height: 100%; background: #27ae60; transition: width 0.3s; }
-.test-summary-bar-fail { height: 100%; background: #e74c3c; transition: width 0.3s; }
+.test-summary-bar-pass {
+  height: 100%;
+  background: #27ae60;
+  transition: width 0.3s;
+}
+.test-summary-bar-fail {
+  height: 100%;
+  background: #e74c3c;
+  transition: width 0.3s;
+}
 
 .test-progress-empty {
   flex: 1;
@@ -4352,9 +4378,16 @@
   gap: 10px;
   color: #aaa;
 }
-.test-progress-empty-icon { font-size: 3rem; }
-.test-progress-empty p { font-size: 1rem; }
-.test-progress-empty-hint { font-size: 0.82rem; color: #bbb; }
+.test-progress-empty-icon {
+  font-size: 3rem;
+}
+.test-progress-empty p {
+  font-size: 1rem;
+}
+.test-progress-empty-hint {
+  font-size: 0.82rem;
+  color: #bbb;
+}
 
 .test-progress-table-wrap {
   flex: 1;
@@ -4368,7 +4401,7 @@
   background: #fff;
   border-radius: 8px;
   overflow: hidden;
-  box-shadow: 0 1px 4px rgba(0,0,0,0.07);
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.07);
   font-size: 0.84rem;
 }
 
@@ -4390,21 +4423,52 @@
   border-bottom: 1px solid #f0f2f5;
   vertical-align: middle;
 }
-.test-progress-row:last-child td { border-bottom: none; }
-.test-progress-row:hover td { background: #f8f9fc; }
+.test-progress-row:last-child td {
+  border-bottom: none;
+}
+.test-progress-row:hover td {
+  background: #f8f9fc;
+}
 
-.tpt-expand { width: 28px; }
-.tpt-name { min-width: 160px; }
-.tpt-task { min-width: 120px; }
-.tpt-assignee { width: 90px; }
-.tpt-due { width: 120px; }
-.tpt-total, .tpt-pass, .tpt-fail { width: 64px; }
-.tpt-not { width: 56px; }
-.tpt-bar { min-width: 100px; }
-.tpt-del { width: 36px; }
+.tpt-expand {
+  width: 28px;
+}
+.tpt-name {
+  min-width: 160px;
+}
+.tpt-task {
+  min-width: 120px;
+}
+.tpt-assignee {
+  width: 90px;
+}
+.tpt-due {
+  width: 120px;
+}
+.tpt-total,
+.tpt-pass,
+.tpt-fail {
+  width: 64px;
+}
+.tpt-not {
+  width: 56px;
+}
+.tpt-bar {
+  min-width: 100px;
+}
+.tpt-del {
+  width: 36px;
+}
 
-.tpt-derived { color: #555; text-align: right; font-size: 0.84rem; padding-right: 14px; }
-.tpt-not.tpt-derived { color: #999; }
+.tpt-derived {
+  color: #555;
+  text-align: right;
+  font-size: 0.84rem;
+  padding-right: 14px;
+}
+.tpt-not.tpt-derived {
+  color: #999;
+}
 
 .tpt-input {
   width: 100%;
@@ -4414,18 +4478,33 @@
   font-size: 0.84rem;
   background: transparent;
   color: inherit;
-  transition: border-color 0.15s, background 0.15s;
+  transition:
+    border-color 0.15s,
+    background 0.15s;
 }
-.tpt-input:hover, .tpt-input:focus {
+.tpt-input:hover,
+.tpt-input:focus {
   border-color: #c0c4d0;
   background: #f5f6fa;
   outline: none;
 }
-.tpt-input--name { font-weight: 500; }
-.tpt-input--num { text-align: right; width: 56px; }
-.tpt-input--pass:focus { border-color: #27ae60; }
-.tpt-input--fail:focus { border-color: #e74c3c; }
-.tpt-input--date { width: 110px; font-size: 0.8rem; }
+.tpt-input--name {
+  font-weight: 500;
+}
+.tpt-input--num {
+  text-align: right;
+  width: 56px;
+}
+.tpt-input--pass:focus {
+  border-color: #27ae60;
+}
+.tpt-input--fail:focus {
+  border-color: #e74c3c;
+}
+.tpt-input--date {
+  width: 110px;
+  font-size: 0.8rem;
+}
 
 .tpt-select {
   width: 100%;
@@ -4437,13 +4516,18 @@
   color: inherit;
   cursor: pointer;
 }
-.tpt-select:hover, .tpt-select:focus {
+.tpt-select:hover,
+.tpt-select:focus {
   border-color: #c0c4d0;
   background: #f5f6fa;
   outline: none;
 }
 
-.tpt-bar-wrap { display: flex; align-items: center; gap: 6px; }
+.tpt-bar-wrap {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
 .tpt-bar-track {
   flex: 1;
   height: 8px;
@@ -4452,9 +4536,23 @@
   overflow: hidden;
   display: flex;
 }
-.tpt-bar-pass { height: 100%; background: #27ae60; transition: width 0.2s; }
-.tpt-bar-fail { height: 100%; background: #e74c3c; transition: width 0.2s; }
-.tpt-bar-pct { font-size: 0.78rem; color: #888; width: 32px; text-align: right; flex-shrink: 0; }
+.tpt-bar-pass {
+  height: 100%;
+  background: #27ae60;
+  transition: width 0.2s;
+}
+.tpt-bar-fail {
+  height: 100%;
+  background: #e74c3c;
+  transition: width 0.2s;
+}
+.tpt-bar-pct {
+  font-size: 0.78rem;
+  color: #888;
+  width: 32px;
+  text-align: right;
+  flex-shrink: 0;
+}
 
 .tpt-expand-btn {
   background: none;
@@ -4465,7 +4563,10 @@
   padding: 2px 4px;
   border-radius: 3px;
 }
-.tpt-expand-btn:hover { background: #e8eaf0; color: #444; }
+.tpt-expand-btn:hover {
+  background: #e8eaf0;
+  color: #444;
+}
 
 .tpt-del-btn {
   background: none;
@@ -4475,11 +4576,19 @@
   padding: 3px 5px;
   border-radius: 4px;
   opacity: 0.4;
-  transition: opacity 0.15s, background 0.15s;
+  transition:
+    opacity 0.15s,
+    background 0.15s;
 }
-.tpt-del-btn:hover { opacity: 1; background: #fdf0ef; }
+.tpt-del-btn:hover {
+  opacity: 1;
+  background: #fdf0ef;
+}
 
-.tpt-sync { width: 64px; text-align: center; }
+.tpt-sync {
+  width: 64px;
+  text-align: center;
+}
 .tpt-sync-btn {
   padding: 3px 8px;
   font-size: 0.78rem;
@@ -4490,9 +4599,14 @@
   border-radius: 4px;
   cursor: pointer;
   white-space: nowrap;
-  transition: background 0.15s, border-color 0.15s;
+  transition:
+    background 0.15s,
+    border-color 0.15s;
 }
-.tpt-sync-btn:hover { background: #bbdefb; border-color: #42a5f5; }
+.tpt-sync-btn:hover {
+  background: #bbdefb;
+  border-color: #42a5f5;
+}
 
 /* 日次ログテーブル */
 .test-progress-log-row td {
@@ -4523,7 +4637,7 @@
   background: #fff;
   border-radius: 6px;
   overflow: hidden;
-  box-shadow: 0 1px 3px rgba(0,0,0,0.06);
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.06);
 }
 
 .tpt-log-table thead tr {
@@ -4544,7 +4658,10 @@
   vertical-align: middle;
 }
 
-.tpt-log-label-col { width: 72px; min-width: 72px; }
+.tpt-log-label-col {
+  width: 72px;
+  min-width: 72px;
+}
 
 .tpt-log-date-col {
   min-width: 84px;
@@ -4552,8 +4669,12 @@
   text-align: center;
   padding: 6px 4px 4px;
 }
-.tpt-log-date-col--saturday { background: #f0f7ff; }
-.tpt-log-date-col--sunday   { background: #fff0f0; }
+.tpt-log-date-col--saturday {
+  background: #f0f7ff;
+}
+.tpt-log-date-col--sunday {
+  background: #fff0f0;
+}
 
 .tpt-log-date-head {
   display: flex;
@@ -4574,8 +4695,12 @@
   font-weight: 600;
   color: #888;
 }
-.tpt-log-weekday--saturday { color: #1e88e5; }
-.tpt-log-weekday--sunday   { color: #e53935; }
+.tpt-log-weekday--saturday {
+  color: #1e88e5;
+}
+.tpt-log-weekday--sunday {
+  color: #e53935;
+}
 
 .tpt-log-row-label {
   font-size: 0.8rem;
@@ -4585,11 +4710,19 @@
   padding: 6px 10px;
   text-align: right;
 }
-.tpt-log-row-label--pass { color: #27ae60; }
-.tpt-log-row-label--fail { color: #e74c3c; }
+.tpt-log-row-label--pass {
+  color: #27ae60;
+}
+.tpt-log-row-label--fail {
+  color: #e74c3c;
+}
 
-.tpt-log-cell--saturday { background: #f0f7ff; }
-.tpt-log-cell--sunday   { background: #fff0f0; }
+.tpt-log-cell--saturday {
+  background: #f0f7ff;
+}
+.tpt-log-cell--sunday {
+  background: #fff0f0;
+}
 
 .tpt-log-input-cell {
   width: 72px;
@@ -4600,15 +4733,22 @@
   font-size: 0.84rem;
   background: transparent;
   color: inherit;
-  transition: border-color 0.15s, background 0.15s;
+  transition:
+    border-color 0.15s,
+    background 0.15s;
 }
-.tpt-log-input-cell:hover, .tpt-log-input-cell:focus {
+.tpt-log-input-cell:hover,
+.tpt-log-input-cell:focus {
   border-color: #c0c4d0;
   background: #f5f6fa;
   outline: none;
 }
-.tpt-log-input--pass:focus { border-color: #27ae60; }
-.tpt-log-input--fail:focus { border-color: #e74c3c; }
+.tpt-log-input--pass:focus {
+  border-color: #27ae60;
+}
+.tpt-log-input--fail:focus {
+  border-color: #e74c3c;
+}
 
 .tpt-log-del-btn {
   background: none;
@@ -4619,9 +4759,15 @@
   border-radius: 3px;
   opacity: 0.3;
   color: #888;
-  transition: opacity 0.15s, background 0.15s;
+  transition:
+    opacity 0.15s,
+    background 0.15s;
 }
-.tpt-log-del-btn:hover { opacity: 1; background: #fdf0ef; color: #e74c3c; }
+.tpt-log-del-btn:hover {
+  opacity: 1;
+  background: #fdf0ef;
+  color: #e74c3c;
+}
 
 .tpt-log-add-row {
   align-self: flex-start;
@@ -4632,59 +4778,187 @@
   font-size: 0.8rem;
   color: #777;
   cursor: pointer;
-  transition: border-color 0.15s, color 0.15s, background 0.15s;
+  transition:
+    border-color 0.15s,
+    color 0.15s,
+    background 0.15s;
 }
-.tpt-log-add-row:hover { border-color: #4a90d9; color: #4a90d9; background: #eef4fc; }
+.tpt-log-add-row:hover {
+  border-color: #4a90d9;
+  color: #4a90d9;
+  background: #eef4fc;
+}
 
 /* ── Dark mode: TestProgressView ── */
 
-[data-theme="dark"] .test-progress-view { background: #121318; }
-[data-theme="dark"] .test-progress-header { background: #1e2028; border-bottom-color: #353845; }
-[data-theme="dark"] .test-progress-title h2 { color: #e2e4f0; }
-[data-theme="dark"] .test-progress-count { background: #2a2d38; color: #6e7080; }
-[data-theme="dark"] .test-progress-filter { background: #2a2d38; border-color: #353845; color: #c0c3d0; }
-[data-theme="dark"] .test-progress-summary { background: #1e2028; border-bottom-color: #353845; }
-[data-theme="dark"] .test-summary-total { color: #a0a3b0; }
-[data-theme="dark"] .test-summary-not { color: #666; }
-[data-theme="dark"] .test-progress-summary-bar { background: #2a2d38; }
-[data-theme="dark"] .test-progress-table { background: #1e2028; box-shadow: none; }
-[data-theme="dark"] .test-progress-table thead tr { background: #252830; border-bottom-color: #353845; }
-[data-theme="dark"] .test-progress-table th { color: #8a8da0; }
-[data-theme="dark"] .test-progress-row td { border-bottom-color: #2a2d38; }
-[data-theme="dark"] .test-progress-row:hover td { background: #252830; }
-[data-theme="dark"] .tpt-not--val { color: #666; }
-[data-theme="dark"] .tpt-input { color: #c0c3d0; }
-[data-theme="dark"] .tpt-input:hover, [data-theme="dark"] .tpt-input:focus { border-color: #454860; background: #252830; }
-[data-theme="dark"] .tpt-select { color: #c0c3d0; }
-[data-theme="dark"] .tpt-select:hover, [data-theme="dark"] .tpt-select:focus { border-color: #454860; background: #252830; }
-[data-theme="dark"] .tpt-bar-track { background: #2a2d38; }
-[data-theme="dark"] .tpt-bar-pct { color: #666; }
-[data-theme="dark"] .tpt-expand-btn { color: #666; }
-[data-theme="dark"] .tpt-expand-btn:hover { background: #2a2d38; color: #c0c3d0; }
-[data-theme="dark"] .tpt-derived { color: #8a8da0; }
-[data-theme="dark"] .tpt-not.tpt-derived { color: #555; }
-[data-theme="dark"] .tpt-del-btn:hover { background: #3a1a1a; }
-[data-theme="dark"] .tpt-sync-btn { color: #64b5f6; background: #1a2535; border-color: #1e3a5f; }
-[data-theme="dark"] .tpt-sync-btn:hover { background: #1e3a5f; border-color: #42a5f5; }
-[data-theme="dark"] .test-progress-log-row td { background: #191b22; border-bottom-color: #2a2d38; }
-[data-theme="dark"] .tpt-log-table { background: #1e2028; }
-[data-theme="dark"] .tpt-log-table thead tr { background: #252830; }
-[data-theme="dark"] .tpt-log-table th { color: #6e7080; }
-[data-theme="dark"] .tpt-log-entry td { border-top-color: #2a2d38; }
-[data-theme="dark"] .tpt-log-input-cell { color: #c0c3d0; }
-[data-theme="dark"] .tpt-log-input-cell:hover, [data-theme="dark"] .tpt-log-input-cell:focus { border-color: #454860; background: #252830; }
-[data-theme="dark"] .tpt-log-del-btn:hover { background: #3a1a1a; }
-[data-theme="dark"] .tpt-log-weekday { color: #555; }
-[data-theme="dark"] .tpt-log-weekday--saturday { color: #64b5f6; }
-[data-theme="dark"] .tpt-log-weekday--sunday   { color: #f44336; }
-[data-theme="dark"] .tpt-log-date-col--saturday { background: #1a2030; }
-[data-theme="dark"] .tpt-log-date-col--sunday   { background: #2a1818; }
-[data-theme="dark"] .tpt-log-cell--saturday { background: #1a2030; }
-[data-theme="dark"] .tpt-log-cell--sunday   { background: #2a1818; }
-[data-theme="dark"] .tpt-log-date-num { color: #c0c3d0; }
-[data-theme="dark"] .tpt-log-row-label { color: #6e7080; }
-[data-theme="dark"] .tpt-log-row-label--pass { color: #2ecc71; }
-[data-theme="dark"] .tpt-log-row-label--fail { color: #e74c3c; }
-[data-theme="dark"] .tpt-log-del-btn:hover { background: #3a1a1a; }
-[data-theme="dark"] .tpt-log-add-row { border-color: #454860; color: #6e7080; }
-[data-theme="dark"] .tpt-log-add-row:hover { border-color: #4a90d9; color: #7eb8f5; background: #1a2d45; }
+[data-theme="dark"] .test-progress-view {
+  background: #121318;
+}
+[data-theme="dark"] .test-progress-header {
+  background: #1e2028;
+  border-bottom-color: #353845;
+}
+[data-theme="dark"] .test-progress-title h2 {
+  color: #e2e4f0;
+}
+[data-theme="dark"] .test-progress-count {
+  background: #2a2d38;
+  color: #6e7080;
+}
+[data-theme="dark"] .test-progress-filter {
+  background: #2a2d38;
+  border-color: #353845;
+  color: #c0c3d0;
+}
+[data-theme="dark"] .test-progress-summary {
+  background: #1e2028;
+  border-bottom-color: #353845;
+}
+[data-theme="dark"] .test-summary-total {
+  color: #a0a3b0;
+}
+[data-theme="dark"] .test-summary-not {
+  color: #666;
+}
+[data-theme="dark"] .test-progress-summary-bar {
+  background: #2a2d38;
+}
+[data-theme="dark"] .test-progress-table {
+  background: #1e2028;
+  box-shadow: none;
+}
+[data-theme="dark"] .test-progress-table thead tr {
+  background: #252830;
+  border-bottom-color: #353845;
+}
+[data-theme="dark"] .test-progress-table th {
+  color: #8a8da0;
+}
+[data-theme="dark"] .test-progress-row td {
+  border-bottom-color: #2a2d38;
+}
+[data-theme="dark"] .test-progress-row:hover td {
+  background: #252830;
+}
+[data-theme="dark"] .tpt-not--val {
+  color: #666;
+}
+[data-theme="dark"] .tpt-input {
+  color: #c0c3d0;
+}
+[data-theme="dark"] .tpt-input:hover,
+[data-theme="dark"] .tpt-input:focus {
+  border-color: #454860;
+  background: #252830;
+}
+[data-theme="dark"] .tpt-select {
+  color: #c0c3d0;
+}
+[data-theme="dark"] .tpt-select:hover,
+[data-theme="dark"] .tpt-select:focus {
+  border-color: #454860;
+  background: #252830;
+}
+[data-theme="dark"] .tpt-bar-track {
+  background: #2a2d38;
+}
+[data-theme="dark"] .tpt-bar-pct {
+  color: #666;
+}
+[data-theme="dark"] .tpt-expand-btn {
+  color: #666;
+}
+[data-theme="dark"] .tpt-expand-btn:hover {
+  background: #2a2d38;
+  color: #c0c3d0;
+}
+[data-theme="dark"] .tpt-derived {
+  color: #8a8da0;
+}
+[data-theme="dark"] .tpt-not.tpt-derived {
+  color: #555;
+}
+[data-theme="dark"] .tpt-del-btn:hover {
+  background: #3a1a1a;
+}
+[data-theme="dark"] .tpt-sync-btn {
+  color: #64b5f6;
+  background: #1a2535;
+  border-color: #1e3a5f;
+}
+[data-theme="dark"] .tpt-sync-btn:hover {
+  background: #1e3a5f;
+  border-color: #42a5f5;
+}
+[data-theme="dark"] .test-progress-log-row td {
+  background: #191b22;
+  border-bottom-color: #2a2d38;
+}
+[data-theme="dark"] .tpt-log-table {
+  background: #1e2028;
+}
+[data-theme="dark"] .tpt-log-table thead tr {
+  background: #252830;
+}
+[data-theme="dark"] .tpt-log-table th {
+  color: #6e7080;
+}
+[data-theme="dark"] .tpt-log-entry td {
+  border-top-color: #2a2d38;
+}
+[data-theme="dark"] .tpt-log-input-cell {
+  color: #c0c3d0;
+}
+[data-theme="dark"] .tpt-log-input-cell:hover,
+[data-theme="dark"] .tpt-log-input-cell:focus {
+  border-color: #454860;
+  background: #252830;
+}
+[data-theme="dark"] .tpt-log-del-btn:hover {
+  background: #3a1a1a;
+}
+[data-theme="dark"] .tpt-log-weekday {
+  color: #555;
+}
+[data-theme="dark"] .tpt-log-weekday--saturday {
+  color: #64b5f6;
+}
+[data-theme="dark"] .tpt-log-weekday--sunday {
+  color: #f44336;
+}
+[data-theme="dark"] .tpt-log-date-col--saturday {
+  background: #1a2030;
+}
+[data-theme="dark"] .tpt-log-date-col--sunday {
+  background: #2a1818;
+}
+[data-theme="dark"] .tpt-log-cell--saturday {
+  background: #1a2030;
+}
+[data-theme="dark"] .tpt-log-cell--sunday {
+  background: #2a1818;
+}
+[data-theme="dark"] .tpt-log-date-num {
+  color: #c0c3d0;
+}
+[data-theme="dark"] .tpt-log-row-label {
+  color: #6e7080;
+}
+[data-theme="dark"] .tpt-log-row-label--pass {
+  color: #2ecc71;
+}
+[data-theme="dark"] .tpt-log-row-label--fail {
+  color: #e74c3c;
+}
+[data-theme="dark"] .tpt-log-del-btn:hover {
+  background: #3a1a1a;
+}
+[data-theme="dark"] .tpt-log-add-row {
+  border-color: #454860;
+  color: #6e7080;
+}
+[data-theme="dark"] .tpt-log-add-row:hover {
+  border-color: #4a90d9;
+  color: #7eb8f5;
+  background: #1a2d45;
+}

--- a/src/types/testBook.ts
+++ b/src/types/testBook.ts
@@ -1,0 +1,15 @@
+export interface DailyLog {
+  date: string; // "YYYY-MM-DD"
+  passCount: number;
+  failCount: number;
+}
+
+export interface TestBook {
+  id: string;
+  name: string;
+  taskId?: string;
+  assignee?: string;
+  dueDate?: string; // "YYYY-MM-DD"
+  totalCount: number;
+  dailyLogs: DailyLog[];
+}

--- a/src/utils/testBookStorage.ts
+++ b/src/utils/testBookStorage.ts
@@ -1,0 +1,19 @@
+import { invoke } from "@tauri-apps/api/core";
+import { TestBook } from "../types/testBook";
+
+export async function loadTestBooks(): Promise<TestBook[]> {
+  try {
+    const saved = await invoke<string | null>("load_test_books");
+    if (saved) {
+      return JSON.parse(saved) as TestBook[];
+    }
+  } catch (e) {
+    console.warn("テストブックの読み込みに失敗:", e);
+  }
+  return [];
+}
+
+export async function saveTestBooks(books: TestBook[]): Promise<void> {
+  const json = JSON.stringify(books);
+  await invoke("save_test_books", { json });
+}


### PR DESCRIPTION
## 概要

テスト工程でのテストブック進捗を管理する専用ビューを追加します。

## 主な機能

- **テストブック管理**: 複数ブックをWBSタスクと紐付けて一元管理
- **日次ログ入力**: 合格数・不合格数を日付ごとにテーブル形式で記録
  - 日付を横方向に並べた転置レイアウト（長期間でも横スクロールで対応）
  - 元タスクの期間（開始〜終了）をデフォルト行として自動生成
  - 土曜（青）・日曜/祝日（赤）のカラーハイライト（ガントチャートと同色系）
  - 今日の列を追加ボタン
- **サマリー表示**: 総件数・合格数・不合格数・未実施数・実施率・合格率をリアルタイム集計
- **担当者オートコンプリート**: 既存タスクの担当者から候補を表示
- **タスク連携**
  - WBSタスク紐付け時に担当者・期限を自動引継ぎ
  - 「↑ 反映」ボタンで実施率を元タスクの進捗率に書き戻し
- **データ永続化**: `testBooks.json` に保存（Tauri バックエンド経由）

## 変更ファイル

| ファイル | 種別 | 内容 |
|---|---|---|
| `src/types/testBook.ts` | 新規 | `TestBook` / `DailyLog` 型定義 |
| `src/utils/testBookStorage.ts` | 新規 | テストブックの読み書きユーティリティ |
| `src/components/TestProgressView.tsx` | 新規 | テスト進捗ビューコンポーネント |
| `src/App.tsx` | 変更 | テスト進捗ビューの組み込み・ナビ追加 |
| `src/styles.css` | 変更 | テスト進捗ビュー用スタイル追加 |
| `src-tauri/src/lib.rs` | 変更 | `load_test_books` / `save_test_books` コマンド追加 |

## Test plan

- [ ] テストブックの追加・削除が正常に動作すること
- [ ] WBSタスクを紐付けると担当者・期限が自動入力されること
- [ ] 日次ログの合格数・不合格数入力がリアルタイムで集計に反映されること
- [ ] 土日・祝日が正しくハイライトされること
- [ ] 「↑ 反映」ボタンで元タスクの進捗率が更新されること
- [ ] アプリ再起動後もデータが保持されること
- [ ] ダークモードで表示が崩れないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)