### PR TITLE
feat: 親タスク追加時に子タスクを自動生成するテンプレート機能を追加

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,7 +8,7 @@ import AnalysisView from "./components/AnalysisView";
 import ArchiveView from "./components/ArchiveView";
 import NoteView from "./components/NoteView";
 import TestProgressView from "./components/TestProgressView";
-import ProxySettingModal from "./components/ProxySettingModal";
+import SettingsModal from "./components/SettingsModal";
 import UpdateNotifier from "./components/UpdateNotifier";
 import DailyTaskPanel from "./components/DailyTaskPanel";
 import { Task } from "./types/task";
@@ -19,6 +19,7 @@ import { loadHolidays } from "./utils/holidays";
 import { sortByTree } from "./utils/taskUtils";
 import { exportToExcel } from "./utils/exportToExcel";
 import { useReminder } from "./hooks/useReminder";
+import { loadAppSettings } from "./utils/settingsStorage";
 
 type ViewMode = "gantt" | "kanban" | "analysis" | "archive" | "note" | "test";
 
@@ -32,6 +33,9 @@ function App() {
   const [viewMode, setViewMode] = useState<ViewMode>("gantt");
   const [searchQuery, setSearchQuery] = useState("");
   const [showProxy, setShowProxy] = useState(false);
+  const [defaultChildTaskNames, setDefaultChildTaskNames] = useState<string[]>(
+    () => loadAppSettings().defaultChildTaskNames,
+  );
   const [exportMsg, setExportMsg] = useState<{ text: string; isError: boolean } | null>(null);
   const [darkMode, setDarkMode] = useState(() => localStorage.getItem("theme") === "dark");
   const [showDailyPanel, setShowDailyPanel] = useState(false);
@@ -284,7 +288,12 @@ function App() {
         </button>
       </header>
 
-      {showProxy && <ProxySettingModal onClose={() => setShowProxy(false)} />}
+      {showProxy && (
+        <SettingsModal
+          onClose={() => setShowProxy(false)}
+          onChildTaskNamesChange={setDefaultChildTaskNames}
+        />
+      )}
       {showDailyPanel && <DailyTaskPanel onClose={() => setShowDailyPanel(false)} />}
 
       {exportMsg && (
@@ -315,7 +324,12 @@ function App() {
           <>
             {isSearching && <SearchView tasks={tasks} query={searchQuery} />}
             {!isSearching && viewMode === "gantt" && (
-              <GanttChart tasks={tasks} onTasksChange={handleTasksChange} holidays={holidays} />
+              <GanttChart
+                tasks={tasks}
+                onTasksChange={handleTasksChange}
+                holidays={holidays}
+                defaultChildTaskNames={defaultChildTaskNames}
+              />
             )}
             {!isSearching && viewMode === "kanban" && (
               <KanbanBoard tasks={tasks} onTasksChange={handleTasksChange} />

--- a/src/components/GanttChart.tsx
+++ b/src/components/GanttChart.tsx
@@ -33,6 +33,7 @@ interface Props {
   tasks: Task[];
   onTasksChange: (tasks: Task[]) => void;
   holidays?: Map<string, string>;
+  defaultChildTaskNames?: string[];
 }
 
 interface AddState {
@@ -45,7 +46,12 @@ interface AddState {
   isFloating?: boolean;
 }
 
-export default function GanttChart({ tasks, onTasksChange, holidays = new Map() }: Props) {
+export default function GanttChart({
+  tasks,
+  onTasksChange,
+  holidays = new Map(),
+  defaultChildTaskNames = [],
+}: Props) {
   const timelineRef = useRef<HTMLDivElement>(null);
   const leftScrollRef = useRef<HTMLDivElement>(null);
 
@@ -154,7 +160,21 @@ export default function GanttChart({ tasks, onTasksChange, holidays = new Map() 
         : {}),
     };
 
-    const appended = [...tasks, newTask];
+    // 親タスク（単発でない・子タスクでない）追加時にデフォルト子タスクを自動生成
+    const autoChildren: Task[] =
+      !addState.parentId && !addState.isFloating && defaultChildTaskNames.length > 0
+        ? defaultChildTaskNames.map((name) => ({
+            id: genId(),
+            name,
+            startDate: newStart,
+            endDate: newEnd,
+            progress: 0,
+            color: addState.color,
+            parentId: newTask.id,
+          }))
+        : [];
+
+    const appended = [...tasks, newTask, ...autoChildren];
     const propagated =
       newTask.parentId && !newTask.isFloating ? propagateDates(newTask.id, appended) : appended;
     onTasksChange(propagated);

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -1,0 +1,283 @@
+/**
+ * SettingsModal – アプリ全体の設定ダイアログ
+ * - デフォルト子タスク設定（親タスク追加時に自動追加される子タスク名リスト）
+ * - HTTP プロキシ設定
+ */
+import { useEffect, useRef, useState } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import { loadAppSettings, saveAppSettings } from "../utils/settingsStorage";
+
+type Tab = "children" | "proxy";
+
+interface Props {
+  onClose: () => void;
+  onChildTaskNamesChange: (names: string[]) => void;
+}
+
+function getErrorMessage(e: unknown): string {
+  return e instanceof Error ? e.message : String(e);
+}
+
+export default function SettingsModal({ onClose, onChildTaskNamesChange }: Props) {
+  const [tab, setTab] = useState<Tab>("children");
+
+  // ── 子タスクテンプレート ──
+  const [childNames, setChildNames] = useState<string[]>(
+    () => loadAppSettings().defaultChildTaskNames,
+  );
+  const [newName, setNewName] = useState("");
+  const [childSaved, setChildSaved] = useState(false);
+  const childTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const newNameInputRef = useRef<HTMLInputElement>(null);
+
+  // ── プロキシ設定 ──
+  const [proxyUrl, setProxyUrl] = useState("");
+  const [proxyStatus, setProxyStatus] = useState<"idle" | "saving" | "saved" | "error">("idle");
+  const [proxyErrMsg, setProxyErrMsg] = useState("");
+  const proxyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    invoke<string | null>("get_proxy_setting")
+      .then((v) => setProxyUrl(v ?? ""))
+      .catch((e) => console.warn("プロキシ設定の読み込みに失敗:", e));
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      if (childTimerRef.current !== null) clearTimeout(childTimerRef.current);
+      if (proxyTimerRef.current !== null) clearTimeout(proxyTimerRef.current);
+    };
+  }, []);
+
+  // ── 子タスク操作 ──
+
+  function addChildName() {
+    const trimmed = newName.trim();
+    if (!trimmed || childNames.includes(trimmed)) return;
+    setChildNames((prev) => [...prev, trimmed]);
+    setNewName("");
+    newNameInputRef.current?.focus();
+  }
+
+  function removeChildName(index: number) {
+    setChildNames((prev) => prev.filter((_, i) => i !== index));
+  }
+
+  function moveUp(index: number) {
+    if (index === 0) return;
+    setChildNames((prev) => {
+      const next = [...prev];
+      [next[index - 1], next[index]] = [next[index], next[index - 1]];
+      return next;
+    });
+  }
+
+  function moveDown(index: number) {
+    setChildNames((prev) => {
+      if (index >= prev.length - 1) return prev;
+      const next = [...prev];
+      [next[index], next[index + 1]] = [next[index + 1], next[index]];
+      return next;
+    });
+  }
+
+  function saveChildSettings() {
+    const settings = loadAppSettings();
+    saveAppSettings({ ...settings, defaultChildTaskNames: childNames });
+    onChildTaskNamesChange(childNames);
+    setChildSaved(true);
+    if (childTimerRef.current !== null) clearTimeout(childTimerRef.current);
+    childTimerRef.current = setTimeout(() => {
+      setChildSaved(false);
+      childTimerRef.current = null;
+    }, 1500);
+  }
+
+  // ── プロキシ操作 ──
+
+  function scheduleProxyReset() {
+    if (proxyTimerRef.current !== null) clearTimeout(proxyTimerRef.current);
+    proxyTimerRef.current = setTimeout(() => {
+      setProxyStatus("idle");
+      proxyTimerRef.current = null;
+    }, 1500);
+  }
+
+  async function handleProxySave() {
+    setProxyStatus("saving");
+    setProxyErrMsg("");
+    try {
+      await invoke("save_proxy_setting", { url: proxyUrl.trim() || null });
+      setProxyStatus("saved");
+      scheduleProxyReset();
+    } catch (e) {
+      setProxyErrMsg(getErrorMessage(e));
+      setProxyStatus("error");
+    }
+  }
+
+  async function handleProxyClear() {
+    setProxyUrl("");
+    setProxyStatus("saving");
+    try {
+      await invoke("save_proxy_setting", { url: null });
+      setProxyStatus("saved");
+      scheduleProxyReset();
+    } catch (e) {
+      setProxyErrMsg(getErrorMessage(e));
+      setProxyStatus("error");
+    }
+  }
+
+  return (
+    <div className="gantt-modal-overlay" onClick={onClose}>
+      <div className="gantt-modal settings-modal" onClick={(e) => e.stopPropagation()}>
+        <h3>設定</h3>
+
+        {/* タブ */}
+        <div className="settings-tabs">
+          <button
+            className={`settings-tab-btn${tab === "children" ? " settings-tab-btn--active" : ""}`}
+            onClick={() => setTab("children")}
+          >
+            子タスクテンプレート
+          </button>
+          <button
+            className={`settings-tab-btn${tab === "proxy" ? " settings-tab-btn--active" : ""}`}
+            onClick={() => setTab("proxy")}
+          >
+            プロキシ設定
+          </button>
+        </div>
+
+        {/* ── 子タスクテンプレート タブ ── */}
+        {tab === "children" && (
+          <div className="settings-tab-content">
+            <p className="settings-desc">
+              親タスク（単発以外）を追加したとき、以下の名前の子タスクを自動で追加します。
+              <br />
+              色は親タスクと同じになります。不要な場合はリストを空にしてください。
+            </p>
+
+            {/* 追加フォーム */}
+            <div className="settings-child-add-row">
+              <input
+                ref={newNameInputRef}
+                type="text"
+                className="assignee-input settings-child-input"
+                placeholder="子タスク名を入力"
+                value={newName}
+                onChange={(e) => setNewName(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") addChildName();
+                }}
+              />
+              <button
+                className="settings-child-add-btn"
+                onClick={addChildName}
+                disabled={!newName.trim()}
+              >
+                追加
+              </button>
+            </div>
+
+            {/* リスト */}
+            {childNames.length === 0 ? (
+              <p className="settings-child-empty">テンプレートなし（自動追加しない）</p>
+            ) : (
+              <ul className="settings-child-list">
+                {childNames.map((name, i) => (
+                  <li key={i} className="settings-child-item">
+                    <span className="settings-child-name">{name}</span>
+                    <div className="settings-child-actions">
+                      <button
+                        className="settings-child-move-btn"
+                        onClick={() => moveUp(i)}
+                        disabled={i === 0}
+                        title="上へ"
+                      >
+                        ▲
+                      </button>
+                      <button
+                        className="settings-child-move-btn"
+                        onClick={() => moveDown(i)}
+                        disabled={i === childNames.length - 1}
+                        title="下へ"
+                      >
+                        ▼
+                      </button>
+                      <button
+                        className="settings-child-remove-btn"
+                        onClick={() => removeChildName(i)}
+                        title="削除"
+                      >
+                        ✕
+                      </button>
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            )}
+
+            {childSaved && <p className="proxy-modal-ok">✓ 保存しました</p>}
+
+            <div className="gantt-modal-actions">
+              <button className="btn-cancel" onClick={onClose}>
+                キャンセル
+              </button>
+              <button className="btn-save" onClick={saveChildSettings}>
+                保存
+              </button>
+            </div>
+          </div>
+        )}
+
+        {/* ── プロキシ設定 タブ ── */}
+        {tab === "proxy" && (
+          <div className="settings-tab-content">
+            <p className="proxy-modal-desc">
+              祝日データ取得時に使用するプロキシを設定します。
+              <br />
+              空欄にすると直接接続（プロキシなし）になります。
+            </p>
+
+            <label className="modal-label">プロキシ URL</label>
+            <input
+              type="text"
+              className="assignee-input"
+              value={proxyUrl}
+              onChange={(e) => setProxyUrl(e.target.value)}
+              placeholder="例: http://proxy.example.com:8080"
+              onKeyDown={(e) => {
+                if (e.key === "Enter") handleProxySave();
+              }}
+              autoFocus
+            />
+            <p className="proxy-modal-hint">
+              認証が必要な場合: <code>http://user:pass@proxy.example.com:8080</code>
+            </p>
+
+            {proxyStatus === "error" && <p className="proxy-modal-error">{proxyErrMsg}</p>}
+            {proxyStatus === "saved" && <p className="proxy-modal-ok">✓ 保存しました</p>}
+
+            <div className="gantt-modal-actions">
+              <button className="btn-cancel" onClick={handleProxyClear}>
+                プロキシを無効化
+              </button>
+              <button className="btn-cancel" onClick={onClose}>
+                キャンセル
+              </button>
+              <button
+                className="btn-save"
+                onClick={handleProxySave}
+                disabled={proxyStatus === "saving"}
+              >
+                {proxyStatus === "saving" ? "保存中…" : "保存"}
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -818,6 +818,135 @@
   min-width: 420px;
   max-width: 520px;
 }
+
+/* 設定モーダル（タブ付き） */
+.settings-modal {
+  min-width: 460px;
+  max-width: 560px;
+}
+.settings-tabs {
+  display: flex;
+  gap: 4px;
+  border-bottom: 2px solid #e2e8f0;
+  margin-bottom: 16px;
+}
+.settings-tab-btn {
+  padding: 6px 14px;
+  font-size: 0.84rem;
+  font-weight: 600;
+  color: #64748b;
+  background: none;
+  border: none;
+  border-bottom: 2px solid transparent;
+  margin-bottom: -2px;
+  cursor: pointer;
+  transition:
+    color 0.15s,
+    border-color 0.15s;
+}
+.settings-tab-btn:hover {
+  color: #334155;
+}
+.settings-tab-btn--active {
+  color: #2563eb;
+  border-bottom-color: #2563eb;
+}
+.settings-tab-content {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.settings-desc {
+  font-size: 0.82rem;
+  color: #64748b;
+  line-height: 1.6;
+}
+.settings-child-add-row {
+  display: flex;
+  gap: 8px;
+}
+.settings-child-input {
+  flex: 1;
+}
+.settings-child-add-btn {
+  padding: 5px 14px;
+  font-size: 0.84rem;
+  font-weight: 600;
+  color: #fff;
+  background: #2563eb;
+  border: none;
+  border-radius: 5px;
+  cursor: pointer;
+  white-space: nowrap;
+}
+.settings-child-add-btn:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+.settings-child-add-btn:not(:disabled):hover {
+  background: #1d4ed8;
+}
+.settings-child-empty {
+  font-size: 0.82rem;
+  color: #94a3b8;
+  text-align: center;
+  padding: 12px 0;
+}
+.settings-child-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.settings-child-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 6px 10px;
+  background: #f8fafc;
+  border: 1px solid #e2e8f0;
+  border-radius: 5px;
+}
+.settings-child-name {
+  font-size: 0.88rem;
+  color: #1e293b;
+}
+.settings-child-actions {
+  display: flex;
+  gap: 4px;
+}
+.settings-child-move-btn {
+  width: 26px;
+  height: 26px;
+  font-size: 0.72rem;
+  color: #64748b;
+  background: none;
+  border: 1px solid #e2e8f0;
+  border-radius: 4px;
+  cursor: pointer;
+}
+.settings-child-move-btn:disabled {
+  opacity: 0.3;
+  cursor: default;
+}
+.settings-child-move-btn:not(:disabled):hover {
+  background: #e2e8f0;
+}
+.settings-child-remove-btn {
+  width: 26px;
+  height: 26px;
+  font-size: 0.8rem;
+  color: #e53935;
+  background: none;
+  border: 1px solid #fecaca;
+  border-radius: 4px;
+  cursor: pointer;
+}
+.settings-child-remove-btn:hover {
+  background: #fef2f2;
+}
 .proxy-modal-desc {
   font-size: 0.82rem;
   color: #64748b;
@@ -3446,6 +3575,47 @@
 }
 [data-theme="dark"] .color-swatch--active {
   border-color: #e2e4f0;
+}
+
+/* ── Settings modal ── */
+[data-theme="dark"] .settings-tabs {
+  border-bottom-color: #353845;
+}
+[data-theme="dark"] .settings-tab-btn {
+  color: #6e7080;
+}
+[data-theme="dark"] .settings-tab-btn:hover {
+  color: #c0c3d0;
+}
+[data-theme="dark"] .settings-tab-btn--active {
+  color: #60a5fa;
+  border-bottom-color: #60a5fa;
+}
+[data-theme="dark"] .settings-desc {
+  color: #6e7080;
+}
+[data-theme="dark"] .settings-child-item {
+  background: #1e2028;
+  border-color: #2a2d38;
+}
+[data-theme="dark"] .settings-child-name {
+  color: #c0c3d0;
+}
+[data-theme="dark"] .settings-child-move-btn {
+  color: #6e7080;
+  border-color: #2a2d38;
+}
+[data-theme="dark"] .settings-child-move-btn:not(:disabled):hover {
+  background: #2a2d38;
+}
+[data-theme="dark"] .settings-child-remove-btn {
+  border-color: #5a2020;
+}
+[data-theme="dark"] .settings-child-remove-btn:hover {
+  background: #3a1a1a;
+}
+[data-theme="dark"] .settings-child-empty {
+  color: #555;
 }
 
 /* ── Proxy modal ── */

--- a/src/utils/settingsStorage.ts
+++ b/src/utils/settingsStorage.ts
@@ -1,0 +1,20 @@
+export interface AppSettings {
+  defaultChildTaskNames: string[];
+}
+
+const KEY = "app_settings";
+const DEFAULT: AppSettings = { defaultChildTaskNames: [] };
+
+export function loadAppSettings(): AppSettings {
+  try {
+    const raw = localStorage.getItem(KEY);
+    if (!raw) return { ...DEFAULT };
+    return { ...DEFAULT, ...JSON.parse(raw) };
+  } catch {
+    return { ...DEFAULT };
+  }
+}
+
+export function saveAppSettings(settings: AppSettings): void {
+  localStorage.setItem(KEY, JSON.stringify(settings));
+}


### PR DESCRIPTION
## 概要

ガントチャートで親タスクを追加する際、あらかじめ設定しておいた子タスク名を自動生成するテンプレート機能を追加します。毎回同じ工程（要件定義・設計・実装・テストなど）を手動で追加する手間を省けます。

## 主な機能

- **設定モーダルをタブ式に刷新**  
  ⚙ボタンから開く設定画面が「子タスクテンプレート」と「プロキシ設定」のタブ構成に
- **子タスクテンプレート管理**
  - テンプレート名の追加・削除・並び替え（↑▼）
  - `localStorage` に永続化
- **自動生成ロジック**  
  ルートタスク（親なし・単発でない）を追加したとき、テンプレートの子タスクを自動で追加  
  色は親タスクと同じになります

## 変更ファイル

| ファイル | 種別 | 内容 |
|---|---|---|
| `src/components/SettingsModal.tsx` | 新規 | タブ式設定モーダル（子タスクテンプレート＋プロキシ） |
| `src/utils/settingsStorage.ts` | 新規 | アプリ設定の localStorage 読み書き |
| `src/components/GanttChart.tsx` | 変更 | `defaultChildTaskNames` prop を接続 |
| `src/App.tsx` | 変更 | 設定モーダル切り替え・state管理・GanttChartへ prop 受け渡し |
| `src/styles.css` | 変更 | 設定モーダル用スタイル追加 |

## Test plan

- [ ] ⚙ボタンで設定モーダルが開くこと
- [ ] 子タスクテンプレートタブでテンプレート名を追加・削除・並び替えできること
- [ ] 保存後にアプリを再起動してもテンプレートが保持されること
- [ ] ガントチャートでルートタスクを追加するとテンプレートの子タスクが自動生成されること
- [ ] 子タスクや単発タスクの追加時は自動生成されないこと
- [ ] テンプレートが空の場合は従来通り子タスクなしで追加されること
- [ ] プロキシ設定タブが従来通り動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)