### PR TITLE
feat: テスト進捗ビューの操作性改善

### DIFF
--- a/src/components/TestProgressView.tsx
+++ b/src/components/TestProgressView.tsx
@@ -344,17 +344,7 @@ export default function TestProgressView({
           <table className="test-progress-table">
             <thead>
               <tr>
-                <th className="tpt-name">ブック名</th>
-                <th className="tpt-task">WBSタスク</th>
-                <th className="tpt-assignee">担当者</th>
-                <th className="tpt-due">期限</th>
-                <th className="tpt-total">総件数</th>
-                <th className="tpt-pass">合格</th>
-                <th className="tpt-fail">不合格</th>
-                <th className="tpt-not">未実施</th>
-                <th className="tpt-bar">進捗</th>
-                <th className="tpt-sync"></th>
-                <th className="tpt-del"></th>
+                <th className="tpt-info-col">ブック情報</th>
                 <th className="tpt-log-col">日次ログ</th>
               </tr>
             </thead>
@@ -370,128 +360,133 @@ export default function TestProgressView({
 
                 return (
                   <tr key={book.id} className="test-progress-row">
-                    <td className="tpt-name">
-                      <input
-                        className="tpt-input tpt-input--name"
-                        value={book.name}
-                        placeholder="ブック名"
-                        onChange={(e) => updateBook(book.id, { name: e.target.value })}
-                      />
-                    </td>
-                    <td className="tpt-task">
-                      <select
-                        className="tpt-select"
-                        value={book.taskId ?? ""}
-                        onChange={(e) => {
-                          const taskId = e.target.value || undefined;
-                          const linked = tasks.find((t) => t.id === taskId);
-                          updateBook(book.id, {
-                            taskId,
-                            ...(linked?.assignee && !book.assignee
-                              ? { assignee: linked.assignee }
-                              : {}),
-                            ...(linked?.endDate && !book.dueDate
-                              ? { dueDate: linked.endDate.toISOString().slice(0, 10) }
-                              : {}),
-                            ...(linked && book.dailyLogs.length === 0
-                              ? { dailyLogs: buildLogsFromTask(linked) }
-                              : {}),
-                          });
-                        }}
-                      >
-                        <option value="">-</option>
-                        {Object.entries(
-                          selectableTasks.reduce<Record<string, Task[]>>((acc, t) => {
-                            const root = getRootTask(t.id, tasks);
-                            const key = root ? root.id : t.id;
-                            (acc[key] ??= []).push(t);
-                            return acc;
-                          }, {}),
-                        ).map(([rootId, leaves]) => {
-                          const rootName = tasks.find((t) => t.id === rootId)?.name ?? "";
-                          return (
-                            <optgroup key={rootId} label={rootName}>
-                              {leaves.map((t) => (
-                                <option key={t.id} value={t.id}>
-                                  {t.name}
-                                </option>
-                              ))}
-                            </optgroup>
-                          );
-                        })}
-                      </select>
-                    </td>
-                    <td className="tpt-assignee">
-                      <AssigneeCombobox
-                        value={book.assignee ?? ""}
-                        onChange={(v) => updateBook(book.id, { assignee: v || undefined })}
-                        suggestions={allMembers}
-                      />
-                    </td>
-                    <td className="tpt-due">
-                      <input
-                        type="date"
-                        className="tpt-input tpt-input--date"
-                        value={book.dueDate ?? ""}
-                        onChange={(e) =>
-                          updateBook(book.id, { dueDate: e.target.value || undefined })
-                        }
-                      />
-                    </td>
-                    <td className="tpt-total">
-                      <input
-                        type="number"
-                        className="tpt-input tpt-input--num"
-                        value={book.totalCount || ""}
-                        min={0}
-                        placeholder="0"
-                        onChange={(e) =>
-                          updateBook(book.id, { totalCount: parseInt(e.target.value, 10) || 0 })
-                        }
-                      />
-                    </td>
-                    <td className="tpt-pass tpt-derived">{pass}</td>
-                    <td className="tpt-fail tpt-derived">{fail}</td>
-                    <td className="tpt-not tpt-derived">{notEx}</td>
-                    <td className="tpt-bar">
-                      <div className="tpt-bar-wrap">
-                        <div className="tpt-bar-track">
-                          <div className="tpt-bar-pass" style={{ width: `${passRateBook}%` }} />
-                          <div
-                            className="tpt-bar-fail"
-                            style={{
-                              width: `${book.totalCount > 0 ? Math.round((fail / book.totalCount) * 100) : 0}%`,
-                            }}
+                    {/* ブック情報カード */}
+                    <td className="tpt-info-col">
+                      <div className="tpt-info-card">
+                        {/* 行1: ブック名 + 削除 */}
+                        <div className="tpt-info-row tpt-info-row--name">
+                          <input
+                            className="tpt-input tpt-input--name"
+                            value={book.name}
+                            placeholder="ブック名"
+                            onChange={(e) => updateBook(book.id, { name: e.target.value })}
+                          />
+                          <button
+                            className="tpt-del-btn"
+                            onClick={() => deleteBook(book.id)}
+                            title="削除"
+                          >
+                            🗑
+                          </button>
+                        </div>
+                        {/* 行2: WBSタスク */}
+                        <select
+                          className="tpt-select tpt-select--full"
+                          value={book.taskId ?? ""}
+                          onChange={(e) => {
+                            const taskId = e.target.value || undefined;
+                            const linked = tasks.find((t) => t.id === taskId);
+                            updateBook(book.id, {
+                              taskId,
+                              ...(linked?.assignee && !book.assignee
+                                ? { assignee: linked.assignee }
+                                : {}),
+                              ...(linked?.endDate && !book.dueDate
+                                ? { dueDate: linked.endDate.toISOString().slice(0, 10) }
+                                : {}),
+                              ...(linked && book.dailyLogs.length === 0
+                                ? { dailyLogs: buildLogsFromTask(linked) }
+                                : {}),
+                            });
+                          }}
+                        >
+                          <option value="">- WBSタスク未選択 -</option>
+                          {Object.entries(
+                            selectableTasks.reduce<Record<string, Task[]>>((acc, t) => {
+                              const root = getRootTask(t.id, tasks);
+                              const key = root ? root.id : t.id;
+                              (acc[key] ??= []).push(t);
+                              return acc;
+                            }, {}),
+                          ).map(([rootId, leaves]) => {
+                            const rootName = tasks.find((t) => t.id === rootId)?.name ?? "";
+                            return (
+                              <optgroup key={rootId} label={rootName}>
+                                {leaves.map((t) => (
+                                  <option key={t.id} value={t.id}>
+                                    {t.name}
+                                  </option>
+                                ))}
+                              </optgroup>
+                            );
+                          })}
+                        </select>
+                        {/* 行3: 担当者 + 期限 */}
+                        <div className="tpt-info-row">
+                          <AssigneeCombobox
+                            value={book.assignee ?? ""}
+                            onChange={(v) => updateBook(book.id, { assignee: v || undefined })}
+                            suggestions={allMembers}
+                          />
+                          <input
+                            type="date"
+                            className="tpt-input tpt-input--date"
+                            value={book.dueDate ?? ""}
+                            onChange={(e) =>
+                              updateBook(book.id, { dueDate: e.target.value || undefined })
+                            }
                           />
                         </div>
-                        <span className="tpt-bar-pct">{rate}%</span>
+                        {/* 行4: 総件数 + 集計 */}
+                        <div className="tpt-info-row tpt-info-row--counts">
+                          <span className="tpt-count-label">総件数</span>
+                          <input
+                            type="number"
+                            className="tpt-input tpt-input--num"
+                            value={book.totalCount || ""}
+                            min={0}
+                            placeholder="0"
+                            onChange={(e) =>
+                              updateBook(book.id, {
+                                totalCount: parseInt(e.target.value, 10) || 0,
+                              })
+                            }
+                          />
+                          <span className="tpt-count-pass">合格 {pass}</span>
+                          <span className="tpt-count-fail">不合格 {fail}</span>
+                          <span className="tpt-count-not">未実施 {notEx}</span>
+                        </div>
+                        {/* 行5: 進捗バー + 反映 */}
+                        <div className="tpt-info-row tpt-info-row--footer">
+                          <div className="tpt-bar-wrap">
+                            <div className="tpt-bar-track">
+                              <div className="tpt-bar-pass" style={{ width: `${passRateBook}%` }} />
+                              <div
+                                className="tpt-bar-fail"
+                                style={{
+                                  width: `${book.totalCount > 0 ? Math.round((fail / book.totalCount) * 100) : 0}%`,
+                                }}
+                              />
+                            </div>
+                            <span className="tpt-bar-pct">{rate}%</span>
+                          </div>
+                          {book.taskId && (
+                            <button
+                              className="tpt-sync-btn"
+                              onClick={() => {
+                                onTasksChange(
+                                  tasks.map((t) =>
+                                    t.id === book.taskId ? { ...t, progress: rate } : t,
+                                  ),
+                                );
+                              }}
+                              title={`実施率 ${rate}% をタスクの進捗率に反映`}
+                            >
+                              ↑ 反映
+                            </button>
+                          )}
+                        </div>
                       </div>
-                    </td>
-                    <td className="tpt-sync">
-                      {book.taskId && (
-                        <button
-                          className="tpt-sync-btn"
-                          onClick={() => {
-                            onTasksChange(
-                              tasks.map((t) =>
-                                t.id === book.taskId ? { ...t, progress: rate } : t,
-                              ),
-                            );
-                          }}
-                          title={`実施率 ${rate}% をタスクの進捗率に反映`}
-                        >
-                          ↑ 反映
-                        </button>
-                      )}
-                    </td>
-                    <td className="tpt-del">
-                      <button
-                        className="tpt-del-btn"
-                        onClick={() => deleteBook(book.id)}
-                        title="削除"
-                      >
-                        🗑
-                      </button>
                     </td>
                     <td className="tpt-log-col">
                       <div className="tpt-log-col-inner">

--- a/src/components/TestProgressView.tsx
+++ b/src/components/TestProgressView.tsx
@@ -470,21 +470,36 @@ export default function TestProgressView({
                             </div>
                             <span className="tpt-bar-pct">{rate}%</span>
                           </div>
-                          {book.taskId && (
-                            <button
-                              className="tpt-sync-btn"
-                              onClick={() => {
-                                onTasksChange(
-                                  tasks.map((t) =>
-                                    t.id === book.taskId ? { ...t, progress: rate } : t,
-                                  ),
-                                );
-                              }}
-                              title={`実施率 ${rate}% をタスクの進捗率に反映`}
-                            >
-                              ↑ 反映
-                            </button>
-                          )}
+                          {book.taskId &&
+                            (() => {
+                              const linked = testBooks.filter((b) => b.taskId === book.taskId);
+                              const totalAll = linked.reduce((s, b) => s + b.totalCount, 0);
+                              const execAll = linked.reduce(
+                                (s, b) => s + sumPass(b.dailyLogs) + sumFail(b.dailyLogs),
+                                0,
+                              );
+                              const combinedRate =
+                                totalAll > 0 ? Math.round((execAll / totalAll) * 100) : 0;
+                              const label =
+                                linked.length > 1
+                                  ? `${linked.length}ブック合算 実施率 ${combinedRate}%`
+                                  : `実施率 ${combinedRate}%`;
+                              return (
+                                <button
+                                  className="tpt-sync-btn"
+                                  onClick={() => {
+                                    onTasksChange(
+                                      tasks.map((t) =>
+                                        t.id === book.taskId ? { ...t, progress: combinedRate } : t,
+                                      ),
+                                    );
+                                  }}
+                                  title={`${label} をタスクの進捗率に反映`}
+                                >
+                                  ↑ 反映
+                                </button>
+                              );
+                            })()}
                         </div>
                       </div>
                     </td>

--- a/src/components/TestProgressView.tsx
+++ b/src/components/TestProgressView.tsx
@@ -159,7 +159,6 @@ export default function TestProgressView({
   holidays = new Map(),
 }: Props) {
   const [filterTaskId, setFilterTaskId] = useState<string>("");
-  const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set());
   const [showBulkInput, setShowBulkInput] = useState(false);
   const [bulkText, setBulkText] = useState("");
 
@@ -202,7 +201,6 @@ export default function TestProgressView({
       dailyLogs: linked ? buildLogsFromTask(linked) : [],
     }));
     onTestBooksChange([...testBooks, ...added]);
-    setExpandedIds((prev) => new Set([...prev, ...added.map((b) => b.id)]));
   }
 
   function confirmBulkAdd() {
@@ -217,15 +215,6 @@ export default function TestProgressView({
 
   function deleteBook(id: string) {
     onTestBooksChange(testBooks.filter((b) => b.id !== id));
-  }
-
-  function toggleExpand(id: string) {
-    setExpandedIds((prev) => {
-      const next = new Set(prev);
-      if (next.has(id)) next.delete(id);
-      else next.add(id);
-      return next;
-    });
   }
 
   function addLogRow(book: TestBook) {
@@ -355,7 +344,6 @@ export default function TestProgressView({
           <table className="test-progress-table">
             <thead>
               <tr>
-                <th className="tpt-expand"></th>
                 <th className="tpt-name">ブック名</th>
                 <th className="tpt-task">WBSタスク</th>
                 <th className="tpt-assignee">担当者</th>
@@ -365,7 +353,9 @@ export default function TestProgressView({
                 <th className="tpt-fail">不合格</th>
                 <th className="tpt-not">未実施</th>
                 <th className="tpt-bar">進捗</th>
+                <th className="tpt-sync"></th>
                 <th className="tpt-del"></th>
+                <th className="tpt-log-col">日次ログ</th>
               </tr>
             </thead>
             <tbody>
@@ -377,272 +367,250 @@ export default function TestProgressView({
                   book.totalCount > 0 ? Math.round(((pass + fail) / book.totalCount) * 100) : 0;
                 const passRateBook =
                   book.totalCount > 0 ? Math.round((pass / book.totalCount) * 100) : 0;
-                const isExpanded = expandedIds.has(book.id);
 
                 return (
-                  <>
-                    <tr key={book.id} className="test-progress-row">
-                      <td className="tpt-expand">
-                        <button
-                          className="tpt-expand-btn"
-                          onClick={() => toggleExpand(book.id)}
-                          title={isExpanded ? "折りたたむ" : "日次ログを展開"}
-                        >
-                          {isExpanded ? "▼" : "▶"}
-                        </button>
-                      </td>
-                      <td className="tpt-name">
-                        <input
-                          className="tpt-input tpt-input--name"
-                          value={book.name}
-                          placeholder="ブック名"
-                          onChange={(e) => updateBook(book.id, { name: e.target.value })}
-                        />
-                      </td>
-                      <td className="tpt-task">
-                        <select
-                          className="tpt-select"
-                          value={book.taskId ?? ""}
-                          onChange={(e) => {
-                            const taskId = e.target.value || undefined;
-                            const linked = tasks.find((t) => t.id === taskId);
-                            updateBook(book.id, {
-                              taskId,
-                              ...(linked?.assignee && !book.assignee
-                                ? { assignee: linked.assignee }
-                                : {}),
-                              ...(linked?.endDate && !book.dueDate
-                                ? { dueDate: linked.endDate.toISOString().slice(0, 10) }
-                                : {}),
-                              ...(linked && book.dailyLogs.length === 0
-                                ? { dailyLogs: buildLogsFromTask(linked) }
-                                : {}),
-                            });
-                          }}
-                        >
-                          <option value="">-</option>
-                          {Object.entries(
-                            selectableTasks.reduce<Record<string, Task[]>>((acc, t) => {
-                              const root = getRootTask(t.id, tasks);
-                              const key = root ? root.id : t.id;
-                              (acc[key] ??= []).push(t);
-                              return acc;
-                            }, {}),
-                          ).map(([rootId, leaves]) => {
-                            const rootName = tasks.find((t) => t.id === rootId)?.name ?? "";
-                            return (
-                              <optgroup key={rootId} label={rootName}>
-                                {leaves.map((t) => (
-                                  <option key={t.id} value={t.id}>
-                                    {t.name}
-                                  </option>
-                                ))}
-                              </optgroup>
-                            );
-                          })}
-                        </select>
-                      </td>
-                      <td className="tpt-assignee">
-                        <AssigneeCombobox
-                          value={book.assignee ?? ""}
-                          onChange={(v) => updateBook(book.id, { assignee: v || undefined })}
-                          suggestions={allMembers}
-                        />
-                      </td>
-                      <td className="tpt-due">
-                        <input
-                          type="date"
-                          className="tpt-input tpt-input--date"
-                          value={book.dueDate ?? ""}
-                          onChange={(e) =>
-                            updateBook(book.id, { dueDate: e.target.value || undefined })
-                          }
-                        />
-                      </td>
-                      <td className="tpt-total">
-                        <input
-                          type="number"
-                          className="tpt-input tpt-input--num"
-                          value={book.totalCount || ""}
-                          min={0}
-                          placeholder="0"
-                          onChange={(e) =>
-                            updateBook(book.id, { totalCount: parseInt(e.target.value, 10) || 0 })
-                          }
-                        />
-                      </td>
-                      <td className="tpt-pass tpt-derived">{pass}</td>
-                      <td className="tpt-fail tpt-derived">{fail}</td>
-                      <td className="tpt-not tpt-derived">{notEx}</td>
-                      <td className="tpt-bar">
-                        <div className="tpt-bar-wrap">
-                          <div className="tpt-bar-track">
-                            <div className="tpt-bar-pass" style={{ width: `${passRateBook}%` }} />
-                            <div
-                              className="tpt-bar-fail"
-                              style={{
-                                width: `${book.totalCount > 0 ? Math.round((fail / book.totalCount) * 100) : 0}%`,
-                              }}
-                            />
-                          </div>
-                          <span className="tpt-bar-pct">{rate}%</span>
-                        </div>
-                      </td>
-                      <td className="tpt-sync">
-                        {book.taskId && (
-                          <button
-                            className="tpt-sync-btn"
-                            onClick={() => {
-                              onTasksChange(
-                                tasks.map((t) =>
-                                  t.id === book.taskId ? { ...t, progress: rate } : t,
-                                ),
-                              );
+                  <tr key={book.id} className="test-progress-row">
+                    <td className="tpt-name">
+                      <input
+                        className="tpt-input tpt-input--name"
+                        value={book.name}
+                        placeholder="ブック名"
+                        onChange={(e) => updateBook(book.id, { name: e.target.value })}
+                      />
+                    </td>
+                    <td className="tpt-task">
+                      <select
+                        className="tpt-select"
+                        value={book.taskId ?? ""}
+                        onChange={(e) => {
+                          const taskId = e.target.value || undefined;
+                          const linked = tasks.find((t) => t.id === taskId);
+                          updateBook(book.id, {
+                            taskId,
+                            ...(linked?.assignee && !book.assignee
+                              ? { assignee: linked.assignee }
+                              : {}),
+                            ...(linked?.endDate && !book.dueDate
+                              ? { dueDate: linked.endDate.toISOString().slice(0, 10) }
+                              : {}),
+                            ...(linked && book.dailyLogs.length === 0
+                              ? { dailyLogs: buildLogsFromTask(linked) }
+                              : {}),
+                          });
+                        }}
+                      >
+                        <option value="">-</option>
+                        {Object.entries(
+                          selectableTasks.reduce<Record<string, Task[]>>((acc, t) => {
+                            const root = getRootTask(t.id, tasks);
+                            const key = root ? root.id : t.id;
+                            (acc[key] ??= []).push(t);
+                            return acc;
+                          }, {}),
+                        ).map(([rootId, leaves]) => {
+                          const rootName = tasks.find((t) => t.id === rootId)?.name ?? "";
+                          return (
+                            <optgroup key={rootId} label={rootName}>
+                              {leaves.map((t) => (
+                                <option key={t.id} value={t.id}>
+                                  {t.name}
+                                </option>
+                              ))}
+                            </optgroup>
+                          );
+                        })}
+                      </select>
+                    </td>
+                    <td className="tpt-assignee">
+                      <AssigneeCombobox
+                        value={book.assignee ?? ""}
+                        onChange={(v) => updateBook(book.id, { assignee: v || undefined })}
+                        suggestions={allMembers}
+                      />
+                    </td>
+                    <td className="tpt-due">
+                      <input
+                        type="date"
+                        className="tpt-input tpt-input--date"
+                        value={book.dueDate ?? ""}
+                        onChange={(e) =>
+                          updateBook(book.id, { dueDate: e.target.value || undefined })
+                        }
+                      />
+                    </td>
+                    <td className="tpt-total">
+                      <input
+                        type="number"
+                        className="tpt-input tpt-input--num"
+                        value={book.totalCount || ""}
+                        min={0}
+                        placeholder="0"
+                        onChange={(e) =>
+                          updateBook(book.id, { totalCount: parseInt(e.target.value, 10) || 0 })
+                        }
+                      />
+                    </td>
+                    <td className="tpt-pass tpt-derived">{pass}</td>
+                    <td className="tpt-fail tpt-derived">{fail}</td>
+                    <td className="tpt-not tpt-derived">{notEx}</td>
+                    <td className="tpt-bar">
+                      <div className="tpt-bar-wrap">
+                        <div className="tpt-bar-track">
+                          <div className="tpt-bar-pass" style={{ width: `${passRateBook}%` }} />
+                          <div
+                            className="tpt-bar-fail"
+                            style={{
+                              width: `${book.totalCount > 0 ? Math.round((fail / book.totalCount) * 100) : 0}%`,
                             }}
-                            title={`実施率 ${rate}% をタスクの進捗率に反映`}
-                          >
-                            ↑ 反映
-                          </button>
-                        )}
-                      </td>
-                      <td className="tpt-del">
+                          />
+                        </div>
+                        <span className="tpt-bar-pct">{rate}%</span>
+                      </div>
+                    </td>
+                    <td className="tpt-sync">
+                      {book.taskId && (
                         <button
-                          className="tpt-del-btn"
-                          onClick={() => deleteBook(book.id)}
-                          title="削除"
+                          className="tpt-sync-btn"
+                          onClick={() => {
+                            onTasksChange(
+                              tasks.map((t) =>
+                                t.id === book.taskId ? { ...t, progress: rate } : t,
+                              ),
+                            );
+                          }}
+                          title={`実施率 ${rate}% をタスクの進捗率に反映`}
                         >
-                          🗑
+                          ↑ 反映
                         </button>
-                      </td>
-                    </tr>
-
-                    {/* 日次ログテーブル（横方向に日付が並ぶ転置レイアウト） */}
-                    {isExpanded && (
-                      <tr key={`${book.id}-log`} className="test-progress-log-row">
-                        <td colSpan={12}>
-                          <div className="tpt-log-area">
-                            <div className="tpt-log-scroll">
-                              <table className="tpt-log-table">
-                                <thead>
-                                  <tr>
-                                    <th className="tpt-log-label-col"></th>
-                                    {book.dailyLogs.map((log) => {
-                                      const { label, isSaturday, isSunday } = getDayOfWeek(
-                                        log.date,
-                                      );
-                                      const holidayName = getHolidayName(log.date, holidays);
-                                      const isRed = isSunday || !!holidayName;
-                                      const [, m, d] = log.date.split("-");
-                                      return (
-                                        <th
-                                          key={log.date}
-                                          className={`tpt-log-date-col${isRed ? " tpt-log-date-col--sunday" : isSaturday ? " tpt-log-date-col--saturday" : ""}`}
-                                          title={holidayName || undefined}
+                      )}
+                    </td>
+                    <td className="tpt-del">
+                      <button
+                        className="tpt-del-btn"
+                        onClick={() => deleteBook(book.id)}
+                        title="削除"
+                      >
+                        🗑
+                      </button>
+                    </td>
+                    <td className="tpt-log-col">
+                      <div className="tpt-log-col-inner">
+                        <div className="tpt-log-scroll">
+                          <table className="tpt-log-table">
+                            <thead>
+                              <tr>
+                                <th className="tpt-log-label-col"></th>
+                                {book.dailyLogs.map((log) => {
+                                  const { label, isSaturday, isSunday } = getDayOfWeek(log.date);
+                                  const holidayName = getHolidayName(log.date, holidays);
+                                  const isRed = isSunday || !!holidayName;
+                                  const [, m, d] = log.date.split("-");
+                                  return (
+                                    <th
+                                      key={log.date}
+                                      className={`tpt-log-date-col${isRed ? " tpt-log-date-col--sunday" : isSaturday ? " tpt-log-date-col--saturday" : ""}`}
+                                      title={holidayName || undefined}
+                                    >
+                                      <div className="tpt-log-date-head">
+                                        <span className="tpt-log-date-num">
+                                          {Number(m)}/{Number(d)}
+                                        </span>
+                                        <span
+                                          className={`tpt-log-weekday${isRed ? " tpt-log-weekday--sunday" : isSaturday ? " tpt-log-weekday--saturday" : ""}`}
                                         >
-                                          <div className="tpt-log-date-head">
-                                            <span className="tpt-log-date-num">
-                                              {Number(m)}/{Number(d)}
-                                            </span>
-                                            <span
-                                              className={`tpt-log-weekday${isRed ? " tpt-log-weekday--sunday" : isSaturday ? " tpt-log-weekday--saturday" : ""}`}
-                                            >
-                                              {holidayName ? "祝" : label}
-                                            </span>
-                                            <button
-                                              className="tpt-log-del-btn"
-                                              onClick={() => deleteLogRow(book, log.date)}
-                                              title="この列を削除"
-                                            >
-                                              ✕
-                                            </button>
-                                          </div>
-                                        </th>
-                                      );
-                                    })}
-                                  </tr>
-                                </thead>
-                                <tbody>
-                                  <tr>
-                                    <td className="tpt-log-row-label tpt-log-row-label--pass">
-                                      合格数
+                                          {holidayName ? "祝" : label}
+                                        </span>
+                                        <button
+                                          className="tpt-log-del-btn"
+                                          onClick={() => deleteLogRow(book, log.date)}
+                                          title="この列を削除"
+                                        >
+                                          ✕
+                                        </button>
+                                      </div>
+                                    </th>
+                                  );
+                                })}
+                              </tr>
+                            </thead>
+                            <tbody>
+                              <tr>
+                                <td className="tpt-log-row-label tpt-log-row-label--pass">
+                                  合格数
+                                </td>
+                                {book.dailyLogs.map((log) => {
+                                  const { isSaturday, isSunday } = getDayOfWeek(log.date);
+                                  const isRed = isSunday || !!getHolidayName(log.date, holidays);
+                                  return (
+                                    <td
+                                      key={log.date}
+                                      className={
+                                        isRed
+                                          ? "tpt-log-cell--sunday"
+                                          : isSaturday
+                                            ? "tpt-log-cell--saturday"
+                                            : ""
+                                      }
+                                    >
+                                      <input
+                                        type="number"
+                                        className="tpt-log-input-cell tpt-log-input--pass"
+                                        value={log.passCount || ""}
+                                        min={0}
+                                        placeholder="0"
+                                        onChange={(e) =>
+                                          updateLogRow(book, log.date, {
+                                            passCount: parseInt(e.target.value, 10) || 0,
+                                          })
+                                        }
+                                      />
                                     </td>
-                                    {book.dailyLogs.map((log) => {
-                                      const { isSaturday, isSunday } = getDayOfWeek(log.date);
-                                      const isRed =
-                                        isSunday || !!getHolidayName(log.date, holidays);
-                                      return (
-                                        <td
-                                          key={log.date}
-                                          className={
-                                            isRed
-                                              ? "tpt-log-cell--sunday"
-                                              : isSaturday
-                                                ? "tpt-log-cell--saturday"
-                                                : ""
-                                          }
-                                        >
-                                          <input
-                                            type="number"
-                                            className="tpt-log-input-cell tpt-log-input--pass"
-                                            value={log.passCount || ""}
-                                            min={0}
-                                            placeholder="0"
-                                            onChange={(e) =>
-                                              updateLogRow(book, log.date, {
-                                                passCount: parseInt(e.target.value, 10) || 0,
-                                              })
-                                            }
-                                          />
-                                        </td>
-                                      );
-                                    })}
-                                  </tr>
-                                  <tr>
-                                    <td className="tpt-log-row-label tpt-log-row-label--fail">
-                                      不合格数
+                                  );
+                                })}
+                              </tr>
+                              <tr>
+                                <td className="tpt-log-row-label tpt-log-row-label--fail">
+                                  不合格数
+                                </td>
+                                {book.dailyLogs.map((log) => {
+                                  const { isSaturday, isSunday } = getDayOfWeek(log.date);
+                                  const isRed = isSunday || !!getHolidayName(log.date, holidays);
+                                  return (
+                                    <td
+                                      key={log.date}
+                                      className={
+                                        isRed
+                                          ? "tpt-log-cell--sunday"
+                                          : isSaturday
+                                            ? "tpt-log-cell--saturday"
+                                            : ""
+                                      }
+                                    >
+                                      <input
+                                        type="number"
+                                        className="tpt-log-input-cell tpt-log-input--fail"
+                                        value={log.failCount || ""}
+                                        min={0}
+                                        placeholder="0"
+                                        onChange={(e) =>
+                                          updateLogRow(book, log.date, {
+                                            failCount: parseInt(e.target.value, 10) || 0,
+                                          })
+                                        }
+                                      />
                                     </td>
-                                    {book.dailyLogs.map((log) => {
-                                      const { isSaturday, isSunday } = getDayOfWeek(log.date);
-                                      const isRed =
-                                        isSunday || !!getHolidayName(log.date, holidays);
-                                      return (
-                                        <td
-                                          key={log.date}
-                                          className={
-                                            isRed
-                                              ? "tpt-log-cell--sunday"
-                                              : isSaturday
-                                                ? "tpt-log-cell--saturday"
-                                                : ""
-                                          }
-                                        >
-                                          <input
-                                            type="number"
-                                            className="tpt-log-input-cell tpt-log-input--fail"
-                                            value={log.failCount || ""}
-                                            min={0}
-                                            placeholder="0"
-                                            onChange={(e) =>
-                                              updateLogRow(book, log.date, {
-                                                failCount: parseInt(e.target.value, 10) || 0,
-                                              })
-                                            }
-                                          />
-                                        </td>
-                                      );
-                                    })}
-                                  </tr>
-                                </tbody>
-                              </table>
-                            </div>
-                            <button className="tpt-log-add-row" onClick={() => addLogRow(book)}>
-                              + 今日の列を追加
-                            </button>
-                          </div>
-                        </td>
-                      </tr>
-                    )}
-                  </>
+                                  );
+                                })}
+                              </tr>
+                            </tbody>
+                          </table>
+                        </div>
+                        <button className="tpt-log-add-row" onClick={() => addLogRow(book)}>
+                          + 今日の列を追加
+                        </button>
+                      </div>
+                    </td>
+                  </tr>
                 );
               })}
             </tbody>

--- a/src/components/TestProgressView.tsx
+++ b/src/components/TestProgressView.tsx
@@ -165,6 +165,12 @@ export default function TestProgressView({
   const childIds = new Set(tasks.map((t) => t.parentId).filter((id): id is string => !!id));
   const selectableTasks = tasks.filter((t) => !t.archived && !childIds.has(t.id));
 
+  useEffect(() => {
+    if (!filterTaskId && selectableTasks.length > 0) {
+      setFilterTaskId(selectableTasks[0].id);
+    }
+  }, [selectableTasks.length]);
+
   const allMembers = [
     ...new Set(
       tasks.flatMap((t) => [t.assignee, ...(t.subMembers ?? [])]).filter((m): m is string => !!m),
@@ -250,7 +256,6 @@ export default function TestProgressView({
             value={filterTaskId}
             onChange={(e) => setFilterTaskId(e.target.value)}
           >
-            <option value="">すべてのタスク</option>
             {Object.entries(
               selectableTasks.reduce<Record<string, Task[]>>((acc, t) => {
                 const root = getRootTask(t.id, tasks);

--- a/src/components/TestProgressView.tsx
+++ b/src/components/TestProgressView.tsx
@@ -144,6 +144,13 @@ function getTaskDepth(taskId: string, tasks: Task[]): number {
   return 1 + getTaskDepth(task.parentId, tasks);
 }
 
+function getRootTask(taskId: string, tasks: Task[]): Task | undefined {
+  const task = tasks.find((t) => t.id === taskId);
+  if (!task) return undefined;
+  if (!task.parentId) return task;
+  return getRootTask(task.parentId, tasks);
+}
+
 export default function TestProgressView({
   tasks,
   testBooks,
@@ -153,8 +160,11 @@ export default function TestProgressView({
 }: Props) {
   const [filterTaskId, setFilterTaskId] = useState<string>("");
   const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set());
+  const [showBulkInput, setShowBulkInput] = useState(false);
+  const [bulkText, setBulkText] = useState("");
 
-  const selectableTasks = tasks.filter((t) => !t.archived);
+  const childIds = new Set(tasks.map((t) => t.parentId).filter((id): id is string => !!id));
+  const selectableTasks = tasks.filter((t) => !t.archived && !childIds.has(t.id));
 
   const allMembers = [
     ...new Set(
@@ -181,17 +191,28 @@ export default function TestProgressView({
     onTestBooksChange(testBooks.map((b) => (b.id === id ? { ...b, ...patch } : b)));
   }
 
-  function addBook() {
+  function addBooks(names: string[]) {
     const linked = tasks.find((t) => t.id === filterTaskId);
-    const book: TestBook = {
+    const added: TestBook[] = names.map((name) => ({
       ...newBook(),
+      name,
       taskId: filterTaskId || undefined,
       assignee: linked?.assignee,
       dueDate: linked ? linked.endDate.toISOString().slice(0, 10) : undefined,
       dailyLogs: linked ? buildLogsFromTask(linked) : [],
-    };
-    onTestBooksChange([...testBooks, book]);
-    setExpandedIds((prev) => new Set([...prev, book.id]));
+    }));
+    onTestBooksChange([...testBooks, ...added]);
+    setExpandedIds((prev) => new Set([...prev, ...added.map((b) => b.id)]));
+  }
+
+  function confirmBulkAdd() {
+    const names = bulkText
+      .split("\n")
+      .map((s) => s.trim())
+      .filter((s) => s.length > 0);
+    if (names.length > 0) addBooks(names);
+    setBulkText("");
+    setShowBulkInput(false);
   }
 
   function deleteBook(id: string) {
@@ -241,23 +262,63 @@ export default function TestProgressView({
             onChange={(e) => setFilterTaskId(e.target.value)}
           >
             <option value="">すべてのタスク</option>
-            {selectableTasks.map((t) => {
-              const depth = getTaskDepth(t.id, tasks);
-              const indent = "    ".repeat(depth);
-              const prefix = depth > 0 ? "└ " : "";
+            {Object.entries(
+              selectableTasks.reduce<Record<string, Task[]>>((acc, t) => {
+                const root = getRootTask(t.id, tasks);
+                const key = root ? root.id : t.id;
+                (acc[key] ??= []).push(t);
+                return acc;
+              }, {}),
+            ).map(([rootId, leaves]) => {
+              const rootName = tasks.find((t) => t.id === rootId)?.name ?? "";
               return (
-                <option key={t.id} value={t.id}>
-                  {indent}
-                  {prefix}
-                  {t.name}
-                </option>
+                <optgroup key={rootId} label={rootName}>
+                  {leaves.map((t) => (
+                    <option key={t.id} value={t.id}>
+                      {t.name}
+                    </option>
+                  ))}
+                </optgroup>
               );
             })}
           </select>
-          <button className="test-progress-add-btn" onClick={addBook}>
+          <button
+            className="test-progress-add-btn"
+            onClick={() => {
+              setBulkText("");
+              setShowBulkInput((v) => !v);
+            }}
+          >
             + ブック追加
           </button>
         </div>
+
+        {/* 一括入力エリア */}
+        {showBulkInput && (
+          <div className="test-progress-bulk-area">
+            <p className="test-progress-bulk-hint">1行につき1ブック名を入力してください</p>
+            <textarea
+              className="test-progress-bulk-textarea"
+              value={bulkText}
+              onChange={(e) => setBulkText(e.target.value)}
+              placeholder={"例:\n結合テスト_画面A\n結合テスト_画面B\n性能テスト"}
+              rows={5}
+              autoFocus
+              onKeyDown={(e) => {
+                if (e.key === "Enter" && (e.ctrlKey || e.metaKey)) confirmBulkAdd();
+                if (e.key === "Escape") setShowBulkInput(false);
+              }}
+            />
+            <div className="test-progress-bulk-actions">
+              <button className="btn-cancel" onClick={() => setShowBulkInput(false)}>
+                キャンセル
+              </button>
+              <button className="btn-save" onClick={confirmBulkAdd} disabled={!bulkText.trim()}>
+                追加 (Ctrl+Enter)
+              </button>
+            </div>
+          </div>
+        )}
       </div>
 
       {/* サマリーバー */}
@@ -360,16 +421,23 @@ export default function TestProgressView({
                           }}
                         >
                           <option value="">-</option>
-                          {selectableTasks.map((t) => {
-                            const depth = getTaskDepth(t.id, tasks);
-                            const indent = "    ".repeat(depth);
-                            const prefix = depth > 0 ? "└ " : "";
+                          {Object.entries(
+                            selectableTasks.reduce<Record<string, Task[]>>((acc, t) => {
+                              const root = getRootTask(t.id, tasks);
+                              const key = root ? root.id : t.id;
+                              (acc[key] ??= []).push(t);
+                              return acc;
+                            }, {}),
+                          ).map(([rootId, leaves]) => {
+                            const rootName = tasks.find((t) => t.id === rootId)?.name ?? "";
                             return (
-                              <option key={t.id} value={t.id}>
-                                {indent}
-                                {prefix}
-                                {t.name}
-                              </option>
+                              <optgroup key={rootId} label={rootName}>
+                                {leaves.map((t) => (
+                                  <option key={t.id} value={t.id}>
+                                    {t.name}
+                                  </option>
+                                ))}
+                              </optgroup>
                             );
                           })}
                         </select>

--- a/src/styles.css
+++ b/src/styles.css
@@ -4638,43 +4638,62 @@
   background: #f8f9fc;
 }
 
-.tpt-name {
-  width: 150px;
+/* ブック情報列: 固定幅カードレイアウト */
+.tpt-info-col {
+  width: 300px;
+  padding: 10px 12px;
+  vertical-align: top;
 }
-.tpt-task {
-  width: 160px;
+.tpt-info-card {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
 }
-.tpt-assignee {
-  width: 88px;
+.tpt-info-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
 }
-.tpt-due {
-  width: 108px;
+.tpt-info-row--name {
+  justify-content: space-between;
 }
-.tpt-total {
-  width: 56px;
+.tpt-info-row--counts {
+  flex-wrap: wrap;
+  gap: 4px 8px;
 }
-.tpt-pass {
-  width: 48px;
+.tpt-info-row--footer {
+  justify-content: space-between;
 }
-.tpt-fail {
-  width: 56px;
+.tpt-count-label {
+  font-size: 0.78rem;
+  color: #888;
+  white-space: nowrap;
 }
-.tpt-not {
-  width: 56px;
+.tpt-count-pass {
+  font-size: 0.8rem;
+  color: #27ae60;
+  font-weight: 600;
+  white-space: nowrap;
 }
-.tpt-bar {
-  width: 130px;
+.tpt-count-fail {
+  font-size: 0.8rem;
+  color: #e74c3c;
+  font-weight: 600;
+  white-space: nowrap;
 }
-.tpt-sync {
-  width: 66px;
+.tpt-count-not {
+  font-size: 0.8rem;
+  color: #aaa;
+  white-space: nowrap;
 }
-.tpt-del {
-  width: 34px;
+.tpt-select--full {
+  width: 100%;
 }
+
 /* ログ列: 残り幅を自動取得 */
 .tpt-log-col {
   overflow: hidden;
-  padding: 6px 8px;
+  padding: 8px 10px;
   vertical-align: top;
 }
 .tpt-log-col-inner {
@@ -5100,6 +5119,12 @@
   color: #8a8da0;
 }
 [data-theme="dark"] .tpt-not.tpt-derived {
+  color: #555;
+}
+[data-theme="dark"] .tpt-count-label {
+  color: #555;
+}
+[data-theme="dark"] .tpt-count-not {
   color: #555;
 }
 [data-theme="dark"] .tpt-del-btn:hover {

--- a/src/styles.css
+++ b/src/styles.css
@@ -4604,6 +4604,7 @@
 
 .test-progress-table {
   width: 100%;
+  table-layout: fixed;
   border-collapse: collapse;
   background: #fff;
   border-radius: 8px;
@@ -4628,7 +4629,7 @@
 .test-progress-row td {
   padding: 6px 10px;
   border-bottom: 1px solid #f0f2f5;
-  vertical-align: middle;
+  vertical-align: top;
 }
 .test-progress-row:last-child td {
   border-bottom: none;
@@ -4637,34 +4638,51 @@
   background: #f8f9fc;
 }
 
-.tpt-expand {
-  width: 28px;
-}
 .tpt-name {
-  min-width: 160px;
+  width: 150px;
 }
 .tpt-task {
-  min-width: 120px;
+  width: 160px;
 }
 .tpt-assignee {
-  width: 90px;
+  width: 88px;
 }
 .tpt-due {
-  width: 120px;
+  width: 108px;
 }
-.tpt-total,
-.tpt-pass,
+.tpt-total {
+  width: 56px;
+}
+.tpt-pass {
+  width: 48px;
+}
 .tpt-fail {
-  width: 64px;
+  width: 56px;
 }
 .tpt-not {
   width: 56px;
 }
 .tpt-bar {
-  min-width: 100px;
+  width: 130px;
+}
+.tpt-sync {
+  width: 66px;
 }
 .tpt-del {
-  width: 36px;
+  width: 34px;
+}
+/* ログ列: 残り幅を自動取得 */
+.tpt-log-col {
+  overflow: hidden;
+  padding: 6px 8px;
+  vertical-align: top;
+}
+.tpt-log-col-inner {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  min-width: 0;
+  overflow: hidden;
 }
 
 .tpt-derived {
@@ -4816,22 +4834,6 @@
 }
 
 /* 日次ログテーブル */
-.test-progress-log-row td {
-  padding: 8px 16px 12px 40px;
-  background: #f5f7fb;
-  border-bottom: 1px solid #e8eaf0;
-  /* テーブルセルがログテーブルの幅で広がらないよう制約 */
-  max-width: 0;
-  overflow: hidden;
-}
-
-.tpt-log-area {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-  min-width: 0;
-  overflow: hidden;
-}
 
 .tpt-log-scroll {
   overflow-x: auto;
@@ -5111,10 +5113,6 @@
 [data-theme="dark"] .tpt-sync-btn:hover {
   background: #1e3a5f;
   border-color: #42a5f5;
-}
-[data-theme="dark"] .test-progress-log-row td {
-  background: #191b22;
-  border-bottom-color: #2a2d38;
 }
 [data-theme="dark"] .tpt-log-table {
   background: #1e2028;

--- a/src/styles.css
+++ b/src/styles.css
@@ -4484,6 +4484,43 @@
   background: #357abd;
 }
 
+.test-progress-bulk-area {
+  padding: 12px 16px 16px;
+  background: #f8fafc;
+  border-top: 1px solid #e2e8f0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.test-progress-bulk-hint {
+  font-size: 0.8rem;
+  color: #64748b;
+  margin: 0;
+}
+.test-progress-bulk-textarea {
+  width: 100%;
+  padding: 8px 10px;
+  font-size: 0.88rem;
+  border: 1px solid #cbd5e1;
+  border-radius: 6px;
+  resize: vertical;
+  font-family: inherit;
+  line-height: 1.6;
+  box-sizing: border-box;
+  background: #fff;
+  color: inherit;
+}
+.test-progress-bulk-textarea:focus {
+  outline: none;
+  border-color: #4a90d9;
+  box-shadow: 0 0 0 2px rgba(74, 144, 217, 0.15);
+}
+.test-progress-bulk-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
 .test-progress-summary {
   padding: 10px 20px;
   background: #fff;
@@ -4963,6 +5000,21 @@
 
 [data-theme="dark"] .test-progress-view {
   background: #121318;
+}
+[data-theme="dark"] .test-progress-bulk-area {
+  background: #191b22;
+  border-top-color: #2a2d38;
+}
+[data-theme="dark"] .test-progress-bulk-hint {
+  color: #6e7080;
+}
+[data-theme="dark"] .test-progress-bulk-textarea {
+  background: #1e2028;
+  border-color: #353845;
+  color: #c0c3d0;
+}
+[data-theme="dark"] .test-progress-bulk-textarea:focus {
+  border-color: #4a90d9;
 }
 [data-theme="dark"] .test-progress-header {
   background: #1e2028;


### PR DESCRIPTION
## Summary

- ブック名の一括入力: テキストエリアで複数行入力し、一度に複数ブックを追加できるようにした
- タスク選択を末端タスクのみに制限: 中間・ルートタスクは選択不可とし、ルート名を optgroup でグループ表示
- レイアウト改善: ブック情報と日次ログを1行に統合し、左カラムを縦積みカードレイアウトに変更
- 反映ボタン: 同一タスクに紐づく全ブックの合算実施率でタスク進捗を更新するよう修正
- フィルター: 「すべてのタスク」選択肢を削除し、初期値を最初のタスクに自動設定

## Test plan

- [ ] ブック追加でテキストエリアに複数行入力 → 複数ブックが一括登録される
- [ ] タスク選択プルダウンに末端タスクのみ表示され、ルート名でグループ化されている
- [ ] ブック情報と日次ログが1行で表示される
- [ ] 同一タスクに複数ブックを紐づけて反映ボタン押下 → 合算実施率でタスク進捗が更新される
- [ ] ページ表示時にフィルターが最初のタスクで初期化されている

🤖 Generated with [Claude Code](https://claude.com/claude-code)