### PR TITLE
fix: Cargo.lockのバージョンを1.3.0に同期

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5501,7 +5501,7 @@ dependencies = [
 
 [[package]]
 name = "wbs"
-version = "1.1.2"
+version = "1.3.0"
 dependencies = [
  "backtrace",
  "chrono",


### PR DESCRIPTION
## Summary
- `src-tauri/Cargo.lock` の `wbs` パッケージバージョンが `1.1.2` のままになっていたため、`Cargo.toml` と一致する `1.3.0` に更新

## Test plan
- [ ] ビルドが通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)